### PR TITLE
Delete a specific version of a schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Options:
   -R, --recursive      Search file recursively.
   -v, --verbose        Enable the verbose mode.
   -V, --version=<version>
-                       Version of the resource to delete (only with <name> parameter).
+                       Version to delete. Only with schema resource and name parameter.
 ```
 
 Example(s):

--- a/README.md
+++ b/README.md
@@ -139,17 +139,12 @@ After a successful authentication, a JWT token signed by Ns4Kafka is written to 
 ## Usage
 
 ```console
-Usage: kafkactl [-hvV] [-n=<optionalNamespace>] [COMMAND]
+Usage: kafkactl [-hV] [COMMAND]
 
-Description:
-
-These are common Kafkactl commands.
+Description: These are common Kafkactl commands.
 
 Options:
   -h, --help      Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                  Override namespace defined in config or YAML resources.
-  -v, --verbose   Enable the verbose mode.
   -V, --version   Print version information and exit.
 
 Commands:
@@ -174,18 +169,15 @@ Commands:
 The `api-resources` command allows you to check which resources can be accessed through the API.
 
 ```console
-Usage: kafkactl api-resources [-hvV] [-n=<optionalNamespace>]
+Usage: kafkactl api-resources [-hv] [-n=<optionalNamespace>]
 
-Description:
-
-Print the supported API resources on the server.
+Description: Print the supported API resources on the server.
 
 Options:
   -h, --help      Show this help message and exit.
   -n, --namespace=<optionalNamespace>
                   Override namespace defined in config or YAML resources.
   -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
 ```
 
 Example(s):
@@ -199,18 +191,12 @@ kafkactl api-resources
 The `auth` command allows you to interact with authentication.
 
 ```console
-Usage: kafkactl auth [-hvV] [-n=<optionalNamespace>] [COMMAND]
+Usage: kafkactl auth [-h] COMMAND
 
-Description:
-
-Interact with authentication.
+Description: Interact with authentication.
 
 Options:
-  -h, --help      Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                  Override namespace defined in config or YAML resources.
-  -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
+  -h, --help   Show this help message and exit.
 
 Commands:
   info   Get the JWT token information.
@@ -222,19 +208,14 @@ Commands:
 The `info` command allows you to get the JWT token information.
 
 ```console
-Usage: kafkactl auth info [-hvV] [-n=<optionalNamespace>] [-o=<output>]
+Usage: kafkactl auth info [-h] [-o=<output>]
 
-Description:
-
-Get the JWT token information.
+Description: Get the JWT token information.
 
 Options:
   -h, --help              Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                          Override namespace defined in config or YAML resources.
   -o, --output=<output>   Output format. One of: yaml|table
-  -v, --verbose           Enable the verbose mode.
-  -V, --version           Print version information and exit.
+
 ```
 
 Example(s):
@@ -248,18 +229,13 @@ kafkactl auth info
 The `renew` command allows you to renew the JWT token.
 
 ```console
-Usage: kafkactl auth renew [-hvV] [-n=<optionalNamespace>]
+Usage: kafkactl auth renew [-hv]
 
-Description:
-
-Renew the JWT token.
+Description: Renew the JWT token.
 
 Options:
   -h, --help      Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                  Override namespace defined in config or YAML resources.
   -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
 ```
 
 Example(s):
@@ -273,11 +249,9 @@ kafkactl auth renew
 The `apply` command allows you to deploy a resource.
 
 ```console
-Usage: kafkactl apply [-hRvV] [--dry-run] [-f=<file>] [-n=<optionalNamespace>]
+Usage: kafkactl apply [-hRv] [--dry-run] [-f=<file>] [-n=<optionalNamespace>]
 
-Description:
-
-Create or update a resource.
+Description: Create or update a resource.
 
 Options:
       --dry-run       Does not persist resources. Validate only.
@@ -287,7 +261,6 @@ Options:
                       Override namespace defined in config or YAML resources.
   -R, --recursive     Search file recursively.
   -v, --verbose       Enable the verbose mode.
-  -V, --version       Print version information and exit.
 ```
 
 Example(s):
@@ -304,18 +277,12 @@ The resources have to be described in YAML manifests.
 The `config` command allows you to manage your Kafka contexts.
 
 ```console
-Usage: kafkactl config [-hvV] [-n=<optionalNamespace>] [COMMAND]
+Usage: kafkactl config [-h] COMMAND
 
-Description:
-
-Manage configuration.
+Description: Manage configuration.
 
 Options:
-  -h, --help      Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                  Override namespace defined in config or YAML resources.
-  -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
+  -h, --help   Show this help message and exit.
 
 Commands:
   get-contexts     Get all contexts.
@@ -328,18 +295,13 @@ Commands:
 The `current-context` command allows you to check the current context.
 
 ```console
-Usage: kafkactl config current-context [-hvV] [-n=<optionalNamespace>]
+Usage: kafkactl config current-context [-hu]
 
-Description:
-
-Get the current context.
+Description: Get the current context.
 
 Options:
-  -h, --help      Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                  Override namespace defined in config or YAML resources.
-  -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
+  -h, --help            Show this help message and exit.
+  -u, --unmask-tokens   Unmask tokens.
 ```
 
 Example(s):
@@ -353,18 +315,13 @@ kafkactl config current-context
 The `get-contexts` command allows you to list all the contexts defined in your configuration file.
 
 ```console
-Usage: kafkactl config get-contexts [-hvV] [-n=<optionalNamespace>]
+Usage: kafkactl config get-contexts [-hu]
 
-Description:
-
-Get all contexts.
+Description: Get all contexts.
 
 Options:
-  -h, --help      Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                  Override namespace defined in config or YAML resources.
-  -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
+  -h, --help            Show this help message and exit.
+  -u, --unmask-tokens   Unmask tokens.
 ```
 
 Example(s):
@@ -378,21 +335,15 @@ kafkactl config get-contexts
 The `use-context` command allows you to switch to a different context.
 
 ```console
-Usage: kafkactl config use-context [-hvV] [-n=<optionalNamespace>] <context>
+Usage: kafkactl config use-context [-h] <context>
 
-Description:
-
-Use a context.
+Description: Use a context.
 
 Parameters:
       <context>   Context to use.
 
 Options:
   -h, --help      Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                  Override namespace defined in config or YAML resources.
-  -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
 ```
 
 Example(s):
@@ -406,18 +357,12 @@ kafkactl config use-context local
 The `connect-cluster` command allows you to interact with Kafka Connect clusters.
 
 ```console
-Usage: kafkactl connect-cluster [-hvV] [-n=<optionalNamespace>] [COMMAND]
+Usage: kafkactl connect-cluster [-h] [COMMAND]
 
-Description:
-
-Interact with connect clusters.
+Description: Interact with connect clusters.
 
 Options:
-  -h, --help      Show this help message and exit.
-  -n, --namespace=<optionalNamespace>
-                  Override namespace defined in config or YAML resources.
-  -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
+  -h, --help   Show this help message and exit.
 
 Commands:
   vault  Vault secrets for a connect cluster.
@@ -428,11 +373,9 @@ Commands:
 The `vault` command allows you to vault sensitive connector configuration.
 
 ```console
-Usage: kafkactl connect-cluster vault [-hvV] [-n=<optionalNamespace>] <connectClusterName> [<secrets>...]
+Usage: kafkactl connect-cluster vault [-hv] [-n=<optionalNamespace>] <connectClusterName> [<secrets>...]
 
-Description:
-
-Vault secrets for a connect cluster.
+Description: Vault secrets for a connect cluster.
 
 Parameters:
       <connectClusterName>   Connect cluster name that will vault the secrets.
@@ -443,7 +386,6 @@ Options:
   -n, --namespace=<optionalNamespace>
                              Override namespace defined in config or YAML resources.
   -v, --verbose              Enable the verbose mode.
-  -V, --version              Print version information and exit.
 ```
 
 - `connectClusterName`: If defined, this option specifies the name of a Connect cluster to use to vault sensitive
@@ -462,11 +404,9 @@ kafkactl connect-cluster vault myConnectCluster someClearText
 The `connector` command allows you to interact with Kafka Connect connectors.
 
 ```console
-Usage: kafkactl connector [-hvV] [-n=<optionalNamespace>] <action> <connectors>...
+Usage: kafkactl connector [-hv] [-n=<optionalNamespace>] <action> <connectors>...
 
-Description:
-
-Interact with connectors.
+Description: Interact with connectors.
 
 Parameters:
       <action>          Action to perform (pause, resume, restart).
@@ -477,7 +417,6 @@ Options:
   -n, --namespace=<optionalNamespace>
                         Override namespace defined in config or YAML resources.
   -v, --verbose         Enable the verbose mode.
-  -V, --version         Print version information and exit.
 ```
 
 - `action`: This option specifies the action to execute, which can be `pause`, `resume`, `restart`
@@ -496,11 +435,9 @@ kafkactl connector restart myConnector
 The `delete-records` command allows you to delete all records within "delete" typed topics.
 
 ```console
-Usage: kafkactl delete-records [-hvV] [--dry-run] [-n=<optionalNamespace>] <topic>
+Usage: kafkactl delete-records [-hv] [--dry-run] [-n=<optionalNamespace>] <topic>
 
-Description:
-
-Delete all records within a topic.
+Description: Delete all records within a topic.
 
 Parameters:
       <topic>     Name of the topic.
@@ -511,7 +448,6 @@ Options:
   -n, --namespace=<optionalNamespace>
                   Override namespace defined in config or YAML resources.
   -v, --verbose   Enable the verbose mode.
-  -V, --version   Print version information and exit.
 ```
 
 Example(s):
@@ -528,8 +464,7 @@ Please note that the resources are deleted instantly and cannot be recovered onc
 with the resource is permanently lost.
 
 ```console
-Usage: kafkactl delete [-hvV] [--dry-run] [-n=<optionalNamespace>] ([<resourceType> <name>] | [[-f=<file>] [-R]])
-
+Usage: kafkactl delete [-hv] [--dry-run] [-n=<optionalNamespace>] ([<resourceType> <name> [-V[=<version>]]] | [[-f=<file>] [-R]])
 Description:
 
 Delete a resource.
@@ -539,14 +474,15 @@ Parameters:
       <name>           Resource name.
 
 Options:
-      --dry-run        Does not persist operation. Validate only.
-  -f, --file=<file>    YAML file or directory containing resources.
+      --dry-run        Does not persist resources. Validate only.
+  -f, --file=<file>    YAML file or directory containing resources to delete.
   -h, --help           Show this help message and exit.
   -n, --namespace=<optionalNamespace>
                        Override namespace defined in config or YAML resources.
   -R, --recursive      Search file recursively.
   -v, --verbose        Enable the verbose mode.
-  -V, --version        Print version information and exit.
+  -V, --version=<version>
+                       Version of the resource to delete (only with <name> parameter).
 ```
 
 Example(s):
@@ -554,6 +490,8 @@ Example(s):
 ```console
 kafkactl delete -f directoryOfResources
 kafkactl delete -f resource.yml
+kafkactl delete myResource
+kafkactl delete mySchema -V latest
 ```
 
 ### Diff
@@ -562,20 +500,17 @@ The `diff` command allows you to compare a new YAML descriptor with the current 
 to easily identify any differences.
 
 ```console
-Usage: kafkactl diff [-hRvV] [-f=<file>] [-n=<optionalNamespace>]
+Usage: kafkactl diff [-hRv] [-f=<file>] [-n=<optionalNamespace>]
 
-Description:
-
-Get differences between a new resource and a old resource.
+Description: Get differences between a new resource and a old resource.
 
 Options:
-  -f, --file=<file>   YAML file or directory containing resources.
+  -f, --file=<file>   YAML file or directory containing resources to compare.
   -h, --help          Show this help message and exit.
   -n, --namespace=<optionalNamespace>
                       Override namespace defined in config or YAML resources.
   -R, --recursive     Search file recursively.
   -v, --verbose       Enable the verbose mode.
-  -V, --version       Print version information and exit.
 ```
 
 Example(s):
@@ -589,11 +524,9 @@ kafkactl diff -f resource.yml
 The `get` command allows you to retrieve information about one or multiple resources.
 
 ```console
-Usage: kafkactl get [-hvV] [-n=<optionalNamespace>] [-o=<output>] <resourceType> [<resourceName>]
+Usage: kafkactl get [-hv] [-n=<optionalNamespace>] [-o=<output>] <resourceType> [<resourceName>]
 
-Description:
-
-Get resources by resource type for the current namespace.
+Description: Get resources by resource type for the current namespace.
 
 Parameters:
       <resourceType>      Resource type or 'all' to display resources of all types.
@@ -605,7 +538,6 @@ Options:
                           Override namespace defined in config or YAML resources.
   -o, --output=<output>   Output format. One of: yaml|table
   -v, --verbose           Enable the verbose mode.
-  -V, --version           Print version information and exit.
 ```
 
 - `resourceType`: This option specifies one of the managed resources: `topic`, `connector`, `acl`, `schema`, `stream`
@@ -626,11 +558,9 @@ The `import` command allows you to import unsynchronized resources between Ns4Ka
 cluster.
 
 ```console
-Usage: kafkactl import [-hvV] [--dry-run] [-n=<optionalNamespace>] <resourceType>
+Usage: kafkactl import [-hv] [--dry-run] [-n=<optionalNamespace>] <resourceType>
 
-Description:
-
-Import non-synchronized resources.
+Description: Import non-synchronized resources.
 
 Parameters:
       <resourceType>   Resource type.
@@ -641,7 +571,6 @@ Options:
   -n, --namespace=<optionalNamespace>
                        Override namespace defined in config or YAML resources.
   -v, --verbose        Enable the verbose mode.
-  -V, --version        Print version information and exit.
 ```
 
 - `resourceType`: This option specifies the type of resource that you want to import, which can be either `topics`
@@ -659,12 +588,10 @@ kafkactl import connects
 The `reset-offsets` command allows you to reset the offsets of consumer groups and topics.
 
 ```console
-Usage: kafkactl reset-offsets [-hvV] [--dry-run] --group=<group> [-n=<optionalNamespace>] (--topic=<topic> | --all-topics) (--to-earliest | --to-latest |
+Usage: kafkactl reset-offsets [-hv] [--dry-run] --group=<group>[-n=<optionalNamespace>] (--topic=<topic> | --all-topics) (--to-earliest | --to-latest |
                         --to-datetime=<datetime> | --shift-by=<shiftBy> | --by-duration=<duration> | --to-offset=<offset>)
 
-Description:
-
-Reset consumer group offsets.
+Description: Reset consumer group offsets.
 
 Options:
       --all-topics           All topics.
@@ -683,7 +610,6 @@ Options:
       --to-offset=<offset>   Set offset to a specific index.
       --topic=<topic>        Topic name or topic:partition.
   -v, --verbose              Enable the verbose mode.
-  -V, --version              Print version information and exit.
 ```
 
 - `--group`: This option specifies one of your consumer group to reset.
@@ -702,11 +628,9 @@ kafkactl reset-offsets --group myConsumerGroup --topic myTopic --to-earliest
 The `reset-password` command allows you to reset the password of a user.
 
 ```console
-Usage: kafkactl reset-password [-hvV] [--execute] [-n=<optionalNamespace>] [-o=<output>] <user>
+Usage: kafkactl reset-password [-hv] [--execute] [-n=<optionalNamespace>] [-o=<output>] <user>
 
-Description:
-
-Reset a Kafka password.
+Description: Reset a Kafka password.
 
 Parameters:
       <user>              The user to reset password.
@@ -718,7 +642,6 @@ Options:
                           Override namespace defined in config or YAML resources.
   -o, --output=<output>   Output format. One of: yaml|table
   -v, --verbose           Enable the verbose mode.
-  -V, --version           Print version information and exit.
 ```
 
 Example(s):
@@ -732,11 +655,9 @@ kafkactl reset-password myUser
 The `schema` command allows you to modify the schema compatibility.
 
 ```console
-Usage: kafkactl schema [-hvV] [-n=<optionalNamespace>] <compatibility> <subjects>...
+Usage: kafkactl schema [-hv] [-n=<optionalNamespace>] <compatibility> <subjects>...
 
-Description:
-
-Interact with schemas.
+Description: Interact with schemas.
 
 Parameters:
       <compatibility>   Compatibility to set (global, backward, backward-transitive, forward, forward-transitive, full, full-transitive, none).
@@ -747,7 +668,6 @@ Options:
   -n, --namespace=<optionalNamespace>
                         Override namespace defined in config or YAML resources.
   -v, --verbose         Enable the verbose mode.
-  -V, --version         Print version information and exit.
 ```
 
 - `compatibility`: This option specifies the compatibility mode to apply.
@@ -784,6 +704,7 @@ spec:
     - tag1
     - tag2
     - tag3
+  description: "myDescription"
 ```
 
 - The `metadata.name` field must be part of your allowed ACLs. Visit your namespace's ACLs to understand which topics

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -27,7 +27,7 @@ public interface NamespacedResourceClient {
      * @param kind         The kind of resource
      * @param resourceName The name of the resource
      * @param token        The auth token
-     * @param version      The version of the resource (schema only)
+     * @param version      The version of the resource, for schemas only.
      * @param dryrun       is dry-run mode or not ?
      * @return The delete response
      */

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -2,6 +2,7 @@ package com.michelin.kafkactl.client;
 
 import com.michelin.kafkactl.client.predicates.RetryTimeoutPredicate;
 import com.michelin.kafkactl.model.Resource;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Delete;
@@ -26,10 +27,11 @@ public interface NamespacedResourceClient {
      * @param kind         The kind of resource
      * @param resourceName The name of the resource
      * @param token        The auth token
+     * @param version      The version of the resource (schema only)
      * @param dryrun       is dry-run mode or not ?
      * @return The delete response
      */
-    @Delete("{namespace}/{kind}/{resourceName}{?dryrun}")
+    @Delete("{namespace}/{kind}/{resourceName}{?version}{?dryrun}")
     @Retryable(delay = "${kafkactl.retry.delete.delay}",
         attempts = "${kafkactl.retry.delete.attempt}",
         multiplier = "${kafkactl.retry.delete.multiplier}",
@@ -39,6 +41,7 @@ public interface NamespacedResourceClient {
         String kind,
         String resourceName,
         @Header("Authorization") String token,
+        @Nullable @QueryValue String version,
         @QueryValue boolean dryrun);
 
     /**

--- a/src/main/java/com/michelin/kafkactl/command/ApiResources.java
+++ b/src/main/java/com/michelin/kafkactl/command/ApiResources.java
@@ -7,7 +7,6 @@ import com.michelin.kafkactl.hook.AuthenticatedHook;
 import com.michelin.kafkactl.model.Metadata;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Inject;
@@ -26,9 +25,7 @@ import picocli.CommandLine.Command;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class ApiResources extends AuthenticatedHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/command/Apply.java
+++ b/src/main/java/com/michelin/kafkactl/command/Apply.java
@@ -5,7 +5,6 @@ import com.michelin.kafkactl.model.ApiResource;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Inject;
@@ -28,9 +27,7 @@ import picocli.CommandLine.ParameterException;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class Apply extends DryRunHook {
     @Inject
     @ReflectiveAccess
@@ -40,7 +37,7 @@ public class Apply extends DryRunHook {
     @ReflectiveAccess
     private ResourceService resourceService;
 
-    @Option(names = {"-f", "--file"}, description = "YAML file or directory containing resources.")
+    @Option(names = {"-f", "--file"}, description = "YAML file or directory containing resources to apply.")
     public Optional<File> file;
 
     @Option(names = {"-R", "--recursive"}, description = "Search file recursively.")

--- a/src/main/java/com/michelin/kafkactl/command/Connector.java
+++ b/src/main/java/com/michelin/kafkactl/command/Connector.java
@@ -10,7 +10,6 @@ import com.michelin.kafkactl.model.Metadata;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Inject;
@@ -34,9 +33,7 @@ import picocli.CommandLine.Parameters;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class Connector extends AuthenticatedHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/command/Delete.java
+++ b/src/main/java/com/michelin/kafkactl/command/Delete.java
@@ -152,7 +152,7 @@ public class Delete extends DryRunHook {
         public String name;
 
         @Option(names = {"-V", "--version"},
-                description = "Version of the resource to delete (only with <name> parameter).", arity = "0..1")
+                description = "Version to delete. Only with schema resource and name parameter.", arity = "0..1")
         public Optional<String> version;
     }
 

--- a/src/main/java/com/michelin/kafkactl/command/Delete.java
+++ b/src/main/java/com/michelin/kafkactl/command/Delete.java
@@ -13,6 +13,7 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Inject;
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
@@ -35,6 +36,8 @@ import picocli.CommandLine.Parameters;
     versionProvider = VersionProvider.class,
     mixinStandardHelpOptions = true)
 public class Delete extends DryRunHook {
+    public static final String VERSION = "version";
+
     @Inject
     @ReflectiveAccess
     private ResourceService resourceService;
@@ -69,8 +72,9 @@ public class Delete extends DryRunHook {
                 .map(resource -> {
                     ApiResource apiResource =
                         apiResourcesService.getResourceDefinitionByKind(resource.getKind()).orElseThrow();
-                    return resourceService.delete(apiResource, namespace, resource.getMetadata().getName(), dryRun,
-                        commandSpec);
+                    Map<String, Object> spec = resource.getSpec();
+                    return resourceService.delete(apiResource, namespace, resource.getMetadata().getName(),
+                        (spec != null ? (String) spec.get(VERSION) : null), dryRun, commandSpec);
                 })
                 .mapToInt(value -> Boolean.TRUE.equals(value) ? 0 : 1)
                 .sum();
@@ -83,7 +87,7 @@ public class Delete extends DryRunHook {
     }
 
     /**
-     * Parse given resources.
+     * Parse input resources (given by file or by name) to build the list of resources to delete.
      *
      * @param namespace The namespace
      * @return A list of resources
@@ -109,32 +113,54 @@ public class Delete extends DryRunHook {
         }
 
         // Generate a single resource with minimum details from input
-        return List.of(Resource.builder()
+        var builder = Resource.builder()
             .metadata(Metadata.builder()
                 .name(config.nameConfig.name)
                 .namespace(namespace)
                 .build())
-            .kind(optionalApiResource.get().getKind())
-            .build());
+            .kind(optionalApiResource.get().getKind());
+
+        if (config.nameConfig.version.isPresent()) {
+            builder = builder.spec(Map.of(VERSION, config.nameConfig.version.get()));
+        }
+        return List.of(builder.build());
     }
 
-    static class EitherOf {
+    /**
+     * By-name of by-file deletion config.
+     */
+    public static class EitherOf {
+        /**
+         * Configuration for deletion by name.
+         */
         @ArgGroup(exclusive = false)
         public ByName nameConfig;
 
+        /**
+         * Configuration for deletion by file.
+         */
         @ArgGroup(exclusive = false)
         public ByFile fileConfig;
     }
 
-    static class ByName {
+    /**
+     * By-name deletion config.
+     */
+    public static class ByName {
         @Parameters(index = "0", description = "Resource type.", arity = "1")
         public String resourceType;
 
         @Parameters(index = "1", description = "Resource name.", arity = "1")
         public String name;
+
+        @Option(names = {"-V", "--version"}, description = "Version of the resource to delete.", arity = "0..1")
+        public Optional<String> version;
     }
 
-    static class ByFile {
+    /**
+     * By-file deletion config.
+     */
+    public static class ByFile {
         @Option(names = {"-f", "--file"}, description = "YAML file or directory containing resources.")
         public Optional<File> file;
 

--- a/src/main/java/com/michelin/kafkactl/command/Delete.java
+++ b/src/main/java/com/michelin/kafkactl/command/Delete.java
@@ -7,7 +7,6 @@ import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FileService;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Inject;
@@ -32,9 +31,7 @@ import picocli.CommandLine.Parameters;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class Delete extends DryRunHook {
     public static final String VERSION = "version";
 
@@ -74,7 +71,7 @@ public class Delete extends DryRunHook {
                         apiResourcesService.getResourceDefinitionByKind(resource.getKind()).orElseThrow();
                     Map<String, Object> spec = resource.getSpec();
                     return resourceService.delete(apiResource, namespace, resource.getMetadata().getName(),
-                        (spec != null ? (String) spec.get(VERSION) : null), dryRun, commandSpec);
+                        (spec != null ? spec.get(VERSION).toString() : null), dryRun, commandSpec);
                 })
                 .mapToInt(value -> Boolean.TRUE.equals(value) ? 0 : 1)
                 .sum();
@@ -153,7 +150,8 @@ public class Delete extends DryRunHook {
         @Parameters(index = "1", description = "Resource name.", arity = "1")
         public String name;
 
-        @Option(names = {"-V", "--version"}, description = "Version of the resource to delete.", arity = "0..1")
+        @Option(names = {"-V", "--version"},
+                description = "Version of the resource to delete (only with <name> parameter).", arity = "0..1")
         public Optional<String> version;
     }
 
@@ -161,7 +159,7 @@ public class Delete extends DryRunHook {
      * By-file deletion config.
      */
     public static class ByFile {
-        @Option(names = {"-f", "--file"}, description = "YAML file or directory containing resources.")
+        @Option(names = {"-f", "--file"}, description = "YAML file or directory containing resources to delete.")
         public Optional<File> file;
 
         @Option(names = {"-R", "--recursive"}, description = "Search file recursively.")

--- a/src/main/java/com/michelin/kafkactl/command/Delete.java
+++ b/src/main/java/com/michelin/kafkactl/command/Delete.java
@@ -71,7 +71,8 @@ public class Delete extends DryRunHook {
                         apiResourcesService.getResourceDefinitionByKind(resource.getKind()).orElseThrow();
                     Map<String, Object> spec = resource.getSpec();
                     return resourceService.delete(apiResource, namespace, resource.getMetadata().getName(),
-                        (spec != null ? spec.get(VERSION).toString() : null), dryRun, commandSpec);
+                        (spec != null && spec.containsKey(VERSION) ? spec.get(VERSION).toString() : null),
+                        dryRun, commandSpec);
                 })
                 .mapToInt(value -> Boolean.TRUE.equals(value) ? 0 : 1)
                 .sum();

--- a/src/main/java/com/michelin/kafkactl/command/DeleteRecords.java
+++ b/src/main/java/com/michelin/kafkactl/command/DeleteRecords.java
@@ -2,7 +2,6 @@ package com.michelin.kafkactl.command;
 
 import com.michelin.kafkactl.hook.DryRunHook;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import picocli.CommandLine.Command;
@@ -19,9 +18,7 @@ import picocli.CommandLine.Parameters;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class DeleteRecords extends DryRunHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/command/Diff.java
+++ b/src/main/java/com/michelin/kafkactl/command/Diff.java
@@ -8,7 +8,6 @@ import com.michelin.kafkactl.model.ApiResource;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -36,9 +35,7 @@ import picocli.CommandLine.ParameterException;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class Diff extends AuthenticatedHook {
     @Inject
     @ReflectiveAccess
@@ -48,7 +45,7 @@ public class Diff extends AuthenticatedHook {
     @ReflectiveAccess
     private FormatService formatService;
 
-    @Option(names = {"-f", "--file"}, description = "YAML file or directory containing resources.")
+    @Option(names = {"-f", "--file"}, description = "YAML file or directory containing resources to compare.")
     public Optional<File> file;
 
     @Option(names = {"-R", "--recursive"}, description = "Search file recursively.")

--- a/src/main/java/com/michelin/kafkactl/command/Get.java
+++ b/src/main/java/com/michelin/kafkactl/command/Get.java
@@ -8,7 +8,6 @@ import com.michelin.kafkactl.model.ApiResource;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Inject;
@@ -31,9 +30,7 @@ import picocli.CommandLine.Parameters;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class Get extends AuthenticatedHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/command/Import.java
+++ b/src/main/java/com/michelin/kafkactl/command/Import.java
@@ -3,7 +3,6 @@ package com.michelin.kafkactl.command;
 import com.michelin.kafkactl.hook.DryRunHook;
 import com.michelin.kafkactl.model.ApiResource;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.util.List;
@@ -23,9 +22,7 @@ import picocli.CommandLine.Parameters;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class Import extends DryRunHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/command/ResetOffsets.java
+++ b/src/main/java/com/michelin/kafkactl/command/ResetOffsets.java
@@ -4,7 +4,6 @@ import com.michelin.kafkactl.hook.DryRunHook;
 import com.michelin.kafkactl.model.Metadata;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.io.IOException;
@@ -28,9 +27,7 @@ import picocli.CommandLine.Option;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class ResetOffsets extends DryRunHook {
     public static final String RESET_METHOD = "method";
     public static final String OPTIONS = "options";

--- a/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
+++ b/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
@@ -5,7 +5,6 @@ import static com.michelin.kafkactl.service.FormatService.YAML;
 
 import com.michelin.kafkactl.hook.AuthenticatedHook;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.io.IOException;
@@ -26,9 +25,7 @@ import picocli.CommandLine.Parameters;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class ResetPassword extends AuthenticatedHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/command/Schema.java
+++ b/src/main/java/com/michelin/kafkactl/command/Schema.java
@@ -8,7 +8,6 @@ import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.model.SchemaCompatibility;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.io.IOException;
@@ -28,9 +27,7 @@ import picocli.CommandLine.Parameters;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class Schema extends AuthenticatedHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/command/auth/Auth.java
+++ b/src/main/java/com/michelin/kafkactl/command/auth/Auth.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command.auth;
 
-import com.michelin.kafkactl.util.VersionProvider;
+import com.michelin.kafkactl.hook.HelpHook;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
@@ -21,10 +21,8 @@ import picocli.CommandLine.Spec;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
-public class Auth {
+    usageHelpAutoWidth = true)
+public class Auth extends HelpHook {
     @Spec
     public CommandSpec commandSpec;
 }

--- a/src/main/java/com/michelin/kafkactl/command/auth/AuthInfo.java
+++ b/src/main/java/com/michelin/kafkactl/command/auth/AuthInfo.java
@@ -2,11 +2,11 @@ package com.michelin.kafkactl.command.auth;
 
 import static com.michelin.kafkactl.util.constant.ResourceKind.AUTH_INFO;
 
+import com.michelin.kafkactl.hook.HelpHook;
 import com.michelin.kafkactl.model.JwtContent;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.LoginService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.io.IOException;
@@ -30,10 +30,8 @@ import picocli.CommandLine.Spec;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
-public class AuthInfo implements Callable<Integer> {
+    usageHelpAutoWidth = true)
+public class AuthInfo extends HelpHook implements Callable<Integer> {
     @Inject
     @ReflectiveAccess
     private LoginService loginService;

--- a/src/main/java/com/michelin/kafkactl/command/auth/AuthRenew.java
+++ b/src/main/java/com/michelin/kafkactl/command/auth/AuthRenew.java
@@ -1,8 +1,8 @@
 package com.michelin.kafkactl.command.auth;
 
+import com.michelin.kafkactl.hook.HelpHook;
 import com.michelin.kafkactl.mixin.VerboseMixin;
 import com.michelin.kafkactl.service.LoginService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.io.IOException;
@@ -23,10 +23,8 @@ import picocli.CommandLine.Spec;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
-public class AuthRenew implements Callable<Integer> {
+    usageHelpAutoWidth = true)
+public class AuthRenew extends HelpHook implements Callable<Integer> {
     @Inject
     @ReflectiveAccess
     private LoginService loginService;

--- a/src/main/java/com/michelin/kafkactl/command/config/Config.java
+++ b/src/main/java/com/michelin/kafkactl/command/config/Config.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command.config;
 
-import com.michelin.kafkactl.util.VersionProvider;
+import com.michelin.kafkactl.hook.HelpHook;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
@@ -23,10 +23,8 @@ import picocli.CommandLine.Spec;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
-public class Config {
+    usageHelpAutoWidth = true)
+public class Config extends HelpHook {
     @Spec
     public CommandSpec commandSpec;
 }

--- a/src/main/java/com/michelin/kafkactl/command/config/ConfigCurrentContext.java
+++ b/src/main/java/com/michelin/kafkactl/command/config/ConfigCurrentContext.java
@@ -10,7 +10,6 @@ import com.michelin.kafkactl.mixin.UnmaskTokenMixin;
 import com.michelin.kafkactl.model.Metadata;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.util.StringUtils;
 import jakarta.inject.Inject;
@@ -31,9 +30,7 @@ import picocli.CommandLine.Mixin;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class ConfigCurrentContext extends ValidCurrentContextHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/command/config/ConfigGetContexts.java
+++ b/src/main/java/com/michelin/kafkactl/command/config/ConfigGetContexts.java
@@ -5,11 +5,11 @@ import static com.michelin.kafkactl.service.FormatService.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONTEXT;
 
 import com.michelin.kafkactl.config.KafkactlConfig;
+import com.michelin.kafkactl.hook.HelpHook;
 import com.michelin.kafkactl.mixin.UnmaskTokenMixin;
 import com.michelin.kafkactl.model.Metadata;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.util.HashMap;
@@ -32,10 +32,8 @@ import picocli.CommandLine.Spec;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
-public class ConfigGetContexts implements Callable<Integer> {
+    usageHelpAutoWidth = true)
+public class ConfigGetContexts extends HelpHook implements Callable<Integer> {
     @Inject
     @ReflectiveAccess
     private KafkactlConfig kafkactlConfig;

--- a/src/main/java/com/michelin/kafkactl/command/config/ConfigUseContext.java
+++ b/src/main/java/com/michelin/kafkactl/command/config/ConfigUseContext.java
@@ -1,8 +1,8 @@
 package com.michelin.kafkactl.command.config;
 
 import com.michelin.kafkactl.config.KafkactlConfig;
+import com.michelin.kafkactl.hook.HelpHook;
 import com.michelin.kafkactl.service.ConfigService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.io.IOException;
@@ -24,10 +24,8 @@ import picocli.CommandLine.Spec;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
-public class ConfigUseContext implements Callable<Integer> {
+    usageHelpAutoWidth = true)
+public class ConfigUseContext extends HelpHook implements Callable<Integer> {
     @Inject
     @ReflectiveAccess
     private KafkactlConfig kafkactlConfig;

--- a/src/main/java/com/michelin/kafkactl/command/connectcluster/ConnectCluster.java
+++ b/src/main/java/com/michelin/kafkactl/command/connectcluster/ConnectCluster.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command.connectcluster;
 
-import com.michelin.kafkactl.util.VersionProvider;
+import com.michelin.kafkactl.hook.HelpHook;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
@@ -20,10 +20,8 @@ import picocli.CommandLine.Spec;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
-public class ConnectCluster {
+    usageHelpAutoWidth = true)
+public class ConnectCluster extends HelpHook {
     @Spec
     public CommandSpec commandSpec;
 }

--- a/src/main/java/com/michelin/kafkactl/command/connectcluster/ConnectClusterVault.java
+++ b/src/main/java/com/michelin/kafkactl/command/connectcluster/ConnectClusterVault.java
@@ -2,7 +2,6 @@ package com.michelin.kafkactl.command.connectcluster;
 
 import com.michelin.kafkactl.hook.AuthenticatedHook;
 import com.michelin.kafkactl.service.ResourceService;
-import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.util.List;
@@ -21,9 +20,7 @@ import picocli.CommandLine.Parameters;
     parameterListHeading = "%n@|bold Parameters|@:%n",
     optionListHeading = "%n@|bold Options|@:%n",
     commandListHeading = "%n@|bold Commands|@:%n",
-    usageHelpAutoWidth = true,
-    versionProvider = VersionProvider.class,
-    mixinStandardHelpOptions = true)
+    usageHelpAutoWidth = true)
 public class ConnectClusterVault extends AuthenticatedHook {
     @Inject
     @ReflectiveAccess

--- a/src/main/java/com/michelin/kafkactl/hook/AuthenticatedHook.java
+++ b/src/main/java/com/michelin/kafkactl/hook/AuthenticatedHook.java
@@ -33,7 +33,7 @@ public abstract class AuthenticatedHook extends ValidCurrentContextHook {
     protected KafkactlConfig kafkactlConfig;
 
     @Mixin
-    public NamespaceMixin namespaceMixinMixin;
+    public NamespaceMixin namespaceMixin;
 
     @Mixin
     public VerboseMixin verboseMixin;
@@ -53,7 +53,7 @@ public abstract class AuthenticatedHook extends ValidCurrentContextHook {
      * @return The current namespace
      */
     protected String getNamespace() {
-        return namespaceMixinMixin.optionalNamespace.orElse(kafkactlConfig.getCurrentNamespace());
+        return namespaceMixin.optionalNamespace.orElse(kafkactlConfig.getCurrentNamespace());
     }
 
     /**

--- a/src/main/java/com/michelin/kafkactl/hook/HelpHook.java
+++ b/src/main/java/com/michelin/kafkactl/hook/HelpHook.java
@@ -1,0 +1,13 @@
+package com.michelin.kafkactl.hook;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Help abstract command.
+ */
+@Command
+public abstract class HelpHook {
+    @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit.")
+    public boolean help;
+}

--- a/src/main/java/com/michelin/kafkactl/hook/ValidCurrentContextHook.java
+++ b/src/main/java/com/michelin/kafkactl/hook/ValidCurrentContextHook.java
@@ -16,7 +16,7 @@ import picocli.CommandLine.Spec;
  * Command hook to check if the current context is valid.
  */
 @Command
-public abstract class ValidCurrentContextHook implements Callable<Integer> {
+public abstract class ValidCurrentContextHook extends HelpHook implements Callable<Integer> {
     @Inject
     @ReflectiveAccess
     protected ConfigService configService;

--- a/src/main/java/com/michelin/kafkactl/mixin/UnmaskTokenMixin.java
+++ b/src/main/java/com/michelin/kafkactl/mixin/UnmaskTokenMixin.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.mixin;
 
-import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 /**
  * Unmask token mixin.
@@ -8,6 +8,6 @@ import picocli.CommandLine;
 public class UnmaskTokenMixin {
     public static final String MASKED = "[MASKED]";
 
-    @CommandLine.Option(names = {"-u", "--unmask-tokens"}, description = "Unmask tokens.")
+    @Option(names = {"-u", "--unmask-tokens"}, description = "Unmask tokens.")
     public boolean unmaskTokens;
 }

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -181,8 +181,8 @@ public class ResourceService {
      * @param apiResource The resource type
      * @param namespace   The namespace
      * @param resource    The resource
-     * @param version     The version of the resource
-     * @param dryRun      Is dry run mode ?
+     * @param version     The version of the resource, for schemas only.
+     * @param dryRun      Is dry run mode?
      * @param commandSpec The command that triggered the action
      * @return true if deletion succeeded, false otherwise
      */

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -199,8 +199,8 @@ public class ResourceService {
                 throw new HttpClientResponseException(response.reason(), response);
             }
 
-            commandSpec.commandLine().getOut().println((version != null ? "Specified version of " : "")
-                + formatService.prettifyKind(apiResource.getKind()) + " \"" + resource + "\" deleted.");
+            commandSpec.commandLine().getOut().println(formatService.prettifyKind(apiResource.getKind())
+                + " \"" + resource + "\"" + (version != null ? " version " + version : "") + " deleted.");
 
             return true;
         } catch (HttpClientResponseException exception) {

--- a/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -226,7 +227,7 @@ class DeleteTest {
 
         when(apiResourcesService.getResourceDefinitionByKind(any()))
             .thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
             .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -238,7 +239,7 @@ class DeleteTest {
     }
 
     @Test
-    void shouldDeleteByNameSuccess() {
+    void shouldDeleteAllVersionsByNameSuccess() {
         when(configService.isCurrentContextValid())
             .thenReturn(true);
         when(loginService.doAuthenticate(any(), anyBoolean()))
@@ -256,7 +257,7 @@ class DeleteTest {
             .thenReturn(Optional.of(apiResource));
         when(apiResourcesService.getResourceDefinitionByKind(any()))
             .thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
             .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -264,6 +265,36 @@ class DeleteTest {
         cmd.setOut(new PrintWriter(sw));
 
         int code = cmd.execute("topic", "prefix.topic", "-n", "namespace");
+        assertEquals(0, code);
+    }
+
+    @Test
+    void shouldDeleteOneVersionByNameSuccess() {
+        when(configService.isCurrentContextValid())
+            .thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean()))
+            .thenReturn(true);
+
+        ApiResource apiResource = ApiResource.builder()
+            .kind("Topic")
+            .path("topics")
+            .names(List.of("topics", "topic", "to"))
+            .namespaced(true)
+            .synchronizable(true)
+            .build();
+
+        when(apiResourcesService.getResourceDefinitionByName(any()))
+            .thenReturn(Optional.of(apiResource));
+        when(apiResourcesService.getResourceDefinitionByKind(any()))
+            .thenReturn(Optional.of(apiResource));
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+            .thenReturn(true);
+
+        CommandLine cmd = new CommandLine(delete);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        int code = cmd.execute("topic", "prefix.topic", "-n", "namespace", "-V", "latest");
         assertEquals(0, code);
     }
 
@@ -298,7 +329,7 @@ class DeleteTest {
 
         when(apiResourcesService.getResourceDefinitionByKind(any()))
             .thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
             .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -342,7 +373,7 @@ class DeleteTest {
 
         when(apiResourcesService.getResourceDefinitionByKind(any()))
             .thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
             .thenReturn(false);
 
         CommandLine cmd = new CommandLine(delete);

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -633,7 +633,7 @@ class ResourceServiceTest {
             "latest", false, cmd.getCommandSpec());
 
         assertTrue(actual);
-        assertTrue(sw.toString().contains("Specified version of Topic \"name\" deleted."));
+        assertTrue(sw.toString().contains("Topic \"name\" version latest deleted."));
     }
 
     @Test


### PR DESCRIPTION
Bind the following two:
- ns4kafka delete schema endpoint DELETE `/<resource>/<resourceName>?version=<version>`
- "-V" and "--version" flags for the command `delete <resource> <resourceName>`

Addition of generic code, and it will only have an effect for schema deletion since only the delete schema endpoint handle the "version" query parameter