### PR TITLE
Fix required execute option for reset-password command

### DIFF
--- a/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
+++ b/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
@@ -60,6 +60,7 @@ public class ResetPassword extends AuthenticatedHook {
                 + "for the namespace " + namespace + ".\n"
                 + "Active connections will be killed instantly.\n\n"
                 + "To execute this operation, rerun the command with option --execute.");
+            return 0;
         }
 
         return resourceService.resetPassword(namespace, user, output, commandSpec);

--- a/src/test/java/com/michelin/kafkactl/command/ResetPasswordTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ResetPasswordTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.michelin.kafkactl.Kafkactl;
 import com.michelin.kafkactl.config.KafkactlConfig;

--- a/src/test/java/com/michelin/kafkactl/command/ResetPasswordTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ResetPasswordTest.java
@@ -5,8 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.michelin.kafkactl.Kafkactl;
 import com.michelin.kafkactl.config.KafkactlConfig;
@@ -104,6 +103,7 @@ class ResetPasswordTest {
         assertTrue(sw.toString().contains("You are about to change your Kafka password for the namespace namespace."));
         assertTrue(sw.toString().contains("Active connections will be killed instantly."));
         assertTrue(sw.toString().contains("To execute this operation, rerun the command with option --execute."));
+        verify(resourceService, never()).resetPassword(any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
The command `kafkactl reset-password <user>` calls ns4kafka API to reset password for the given user in addition to displaying the prevention message. I don't think it is the expected behaviour since we have the `--execute` option which should be mandatory for this command execution.

I made the code exit in case the `--execute` option is not provided in the `kafkactl reset-password <user>` command ; and improved the unit test to include this behaviour.