### PR TITLE
Add yml output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Description: Get the JWT token information.
 
 Options:
   -h, --help              Show this help message and exit.
-  -o, --output=<output>   Output format. One of: yaml|table
+  -o, --output=<output>   Output format (yaml, yml, table).
 ```
 
 Example(s):
@@ -541,7 +541,7 @@ Options:
   -n, --namespace=<optionalNamespace>
                             Override namespace defined in config or YAML
                               resources.
-  -o, --output=<output>     Output format. One of: yaml|table
+  -o, --output=<output>   Output format (yaml, yml, table).
       --search[=<String=String>[,<String=String>...]]
                           Search resources based on parameters.
   -v, --verbose             Enable the verbose mode.
@@ -651,7 +651,7 @@ Options:
   -h, --help              Show this help message and exit.
   -n, --namespace=<optionalNamespace>
                           Override namespace defined in config or YAML resources.
-  -o, --output=<output>   Output format. One of: yaml|table
+  -o, --output=<output>   Output format (yaml, yml, table).
   -v, --verbose           Enable the verbose mode.
 ```
 

--- a/README.md
+++ b/README.md
@@ -537,14 +537,14 @@ Parameters:
       [<resourceName>]    Resource name or wildcard matching resource names.
 
 Options:
-  -h, --help                Show this help message and exit.
+  -h, --help              Show this help message and exit.
   -n, --namespace=<optionalNamespace>
-                            Override namespace defined in config or YAML
-                              resources.
+                          Override namespace defined in config or YAML
+                            resources.
   -o, --output=<output>   Output format (yaml, yml, table).
       --search[=<String=String>[,<String=String>...]]
                           Search resources based on parameters.
-  -v, --verbose             Enable the verbose mode.
+  -v, --verbose           Enable the verbose mode.
 ```
 
 - `resourceType`: This option specifies one of the managed resources: `topic`, `connector`, `acl`, `schema`, `stream`

--- a/src/main/java/com/michelin/kafkactl/command/ApiResources.java
+++ b/src/main/java/com/michelin/kafkactl/command/ApiResources.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.RESOURCE_DEFINITION;
 
 import com.michelin.kafkactl.hook.AuthenticatedHook;

--- a/src/main/java/com/michelin/kafkactl/command/ApiResources.java
+++ b/src/main/java/com/michelin/kafkactl/command/ApiResources.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.RESOURCE_DEFINITION;
 
 import com.michelin.kafkactl.hook.AuthenticatedHook;

--- a/src/main/java/com/michelin/kafkactl/command/Connector.java
+++ b/src/main/java/com/michelin/kafkactl/command/Connector.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CHANGE_CONNECTOR_STATE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECTOR;
 

--- a/src/main/java/com/michelin/kafkactl/command/Connector.java
+++ b/src/main/java/com/michelin/kafkactl/command/Connector.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CHANGE_CONNECTOR_STATE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECTOR;
 
@@ -43,11 +43,16 @@ public class Connector extends AuthenticatedHook {
     @ReflectiveAccess
     private FormatService formatService;
 
-    @Parameters(index = "0", description = "Action to perform (${COMPLETION-CANDIDATES}).", arity = "1")
+    @Parameters(
+        index = "0",
+        description = "Action to perform (${COMPLETION-CANDIDATES}).",
+        arity = "1")
     public ConnectorAction action;
 
-    @Parameters(index = "1..*",
-        description = "Connector names separated by space or \"all\" for all connectors.", arity = "1..*")
+    @Parameters(
+        index = "1..*",
+        description = "Connector names separated by space or \"all\" for all connectors.",
+        arity = "1..*")
     public List<String> connectors;
 
     /**

--- a/src/main/java/com/michelin/kafkactl/command/Get.java
+++ b/src/main/java/com/michelin/kafkactl/command/Get.java
@@ -1,7 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
-import static com.michelin.kafkactl.service.FormatService.YAML;
+import static com.michelin.kafkactl.service.FormatService.Output;
 
 import com.michelin.kafkactl.hook.AuthenticatedHook;
 import com.michelin.kafkactl.model.ApiResource;
@@ -62,9 +61,9 @@ public class Get extends AuthenticatedHook {
 
     @Option(
         names = {"-o", "--output"},
-        description = "Output format. One of: yaml|table",
+        description = "Output format. One of: yml|yaml|table",
         defaultValue = "table")
-    public String output;
+    public Output output;
 
     /**
      * Run the "get" command.
@@ -77,24 +76,11 @@ public class Get extends AuthenticatedHook {
         // Validate resourceType + custom type ALL
         List<ApiResource> apiResources = validateResourceType();
 
-        // Validate -o flag
-        validateOutput();
-
         try {
             return resourceService.list(apiResources, getNamespace(), resourceName, search, output, commandSpec);
         } catch (HttpClientResponseException e) {
             formatService.displayError(e, apiResources.getFirst().getKind(), resourceName, commandSpec);
             return 1;
-        }
-    }
-
-    /**
-     * Validate required output format.
-     */
-    private void validateOutput() {
-        if (!List.of(TABLE, YAML).contains(output)) {
-            throw new ParameterException(commandSpec.commandLine(),
-                "Invalid value " + output + " for option -o.");
         }
     }
 

--- a/src/main/java/com/michelin/kafkactl/command/Get.java
+++ b/src/main/java/com/michelin/kafkactl/command/Get.java
@@ -1,9 +1,8 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output;
-
 import com.michelin.kafkactl.hook.AuthenticatedHook;
 import com.michelin.kafkactl.model.ApiResource;
+import com.michelin.kafkactl.model.Output;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.ResourceService;
 import io.micronaut.core.annotation.ReflectiveAccess;
@@ -61,7 +60,7 @@ public class Get extends AuthenticatedHook {
 
     @Option(
         names = {"-o", "--output"},
-        description = "Output format. One of: yml|yaml|table",
+        description = "Output format (${COMPLETION-CANDIDATES}).",
         defaultValue = "table")
     public Output output;
 

--- a/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
+++ b/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
@@ -7,11 +7,8 @@ import com.michelin.kafkactl.service.ResourceService;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Stream;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Parameters;
 
 /**

--- a/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
+++ b/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
@@ -1,8 +1,7 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output;
-
 import com.michelin.kafkactl.hook.AuthenticatedHook;
+import com.michelin.kafkactl.model.Output;
 import com.michelin.kafkactl.service.ResourceService;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
@@ -40,7 +39,7 @@ public class ResetPassword extends AuthenticatedHook {
 
     @Option(
         names = {"-o", "--output"},
-        description = "Output format. One of: yml|yaml|table",
+        description = "Output format (${COMPLETION-CANDIDATES}).",
         defaultValue = "table")
     public Output output;
 

--- a/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
+++ b/src/main/java/com/michelin/kafkactl/command/ResetPassword.java
@@ -1,7 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
-import static com.michelin.kafkactl.service.FormatService.YAML;
+import static com.michelin.kafkactl.service.FormatService.Output;
 
 import com.michelin.kafkactl.hook.AuthenticatedHook;
 import com.michelin.kafkactl.service.ResourceService;
@@ -9,6 +8,7 @@ import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
@@ -31,15 +31,21 @@ public class ResetPassword extends AuthenticatedHook {
     @ReflectiveAccess
     private ResourceService resourceService;
 
-    @Parameters(description = "The user to reset password.", arity = "1")
+    @Parameters(
+        description = "The user to reset password.",
+        arity = "1")
     public String user;
 
-    @Option(names = {"--execute"}, description = "This option is mandatory to change the password")
+    @Option(
+        names = {"--execute"},
+        description = "This option is mandatory to change the password")
     public boolean confirmed;
 
-    @Option(names = {"-o",
-        "--output"}, description = "Output format. One of: yaml|table", defaultValue = "table")
-    public String output;
+    @Option(
+        names = {"-o", "--output"},
+        description = "Output format. One of: yml|yaml|table",
+        defaultValue = "table")
+    public Output output;
 
     /**
      * Run the "users" command.
@@ -49,11 +55,6 @@ public class ResetPassword extends AuthenticatedHook {
      */
     @Override
     public Integer onAuthSuccess() throws IOException {
-        if (!List.of(TABLE, YAML).contains(output)) {
-            throw new ParameterException(commandSpec.commandLine(),
-                "Invalid value " + output + " for option -o.");
-        }
-
         String namespace = getNamespace();
         if (!confirmed) {
             commandSpec.commandLine().getOut().println("You are about to change your Kafka password "

--- a/src/main/java/com/michelin/kafkactl/command/Schema.java
+++ b/src/main/java/com/michelin/kafkactl/command/Schema.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.SCHEMA_COMPATIBILITY_STATE;
 
 import com.michelin.kafkactl.hook.AuthenticatedHook;

--- a/src/main/java/com/michelin/kafkactl/command/Schema.java
+++ b/src/main/java/com/michelin/kafkactl/command/Schema.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.SCHEMA_COMPATIBILITY_STATE;
 
 import com.michelin.kafkactl.hook.AuthenticatedHook;
@@ -37,10 +37,16 @@ public class Schema extends AuthenticatedHook {
     @ReflectiveAccess
     private FormatService formatService;
 
-    @Parameters(index = "0", description = "Compatibility to set (${COMPLETION-CANDIDATES}).", arity = "1")
+    @Parameters(
+        index = "0",
+        description = "Compatibility to set (${COMPLETION-CANDIDATES}).",
+        arity = "1")
     public SchemaCompatibility compatibility;
 
-    @Parameters(index = "1..*", description = "Subject names separated by space.", arity = "1..*")
+    @Parameters(
+        index = "1..*",
+        description = "Subject names separated by space.",
+        arity = "1..*")
     public List<String> subjects;
 
     /**

--- a/src/main/java/com/michelin/kafkactl/command/auth/AuthInfo.java
+++ b/src/main/java/com/michelin/kafkactl/command/auth/AuthInfo.java
@@ -1,5 +1,6 @@
 package com.michelin.kafkactl.command.auth;
 
+import static com.michelin.kafkactl.service.FormatService.Output;
 import static com.michelin.kafkactl.util.constant.ResourceKind.AUTH_INFO;
 
 import com.michelin.kafkactl.hook.HelpHook;
@@ -44,9 +45,11 @@ public class AuthInfo extends HelpHook implements Callable<Integer> {
     @Spec
     public CommandSpec commandSpec;
 
-    @Option(names = {"-o",
-        "--output"}, description = "Output format. One of: yaml|table", defaultValue = "table")
-    public String output;
+    @Option(
+        names = {"-o", "--output"},
+        description = "Output format. One of: yml|yaml|table",
+        defaultValue = "table")
+    public Output output;
 
     @Override
     public Integer call() throws IOException {

--- a/src/main/java/com/michelin/kafkactl/command/auth/AuthInfo.java
+++ b/src/main/java/com/michelin/kafkactl/command/auth/AuthInfo.java
@@ -1,10 +1,10 @@
 package com.michelin.kafkactl.command.auth;
 
-import static com.michelin.kafkactl.service.FormatService.Output;
 import static com.michelin.kafkactl.util.constant.ResourceKind.AUTH_INFO;
 
 import com.michelin.kafkactl.hook.HelpHook;
 import com.michelin.kafkactl.model.JwtContent;
+import com.michelin.kafkactl.model.Output;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.service.FormatService;
 import com.michelin.kafkactl.service.LoginService;
@@ -47,7 +47,7 @@ public class AuthInfo extends HelpHook implements Callable<Integer> {
 
     @Option(
         names = {"-o", "--output"},
-        description = "Output format. One of: yml|yaml|table",
+        description = "Output format (${COMPLETION-CANDIDATES}).",
         defaultValue = "table")
     public Output output;
 

--- a/src/main/java/com/michelin/kafkactl/command/config/ConfigCurrentContext.java
+++ b/src/main/java/com/michelin/kafkactl/command/config/ConfigCurrentContext.java
@@ -1,7 +1,7 @@
 package com.michelin.kafkactl.command.config;
 
 import static com.michelin.kafkactl.mixin.UnmaskTokenMixin.MASKED;
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONTEXT;
 
 import com.michelin.kafkactl.config.KafkactlConfig;

--- a/src/main/java/com/michelin/kafkactl/command/config/ConfigCurrentContext.java
+++ b/src/main/java/com/michelin/kafkactl/command/config/ConfigCurrentContext.java
@@ -1,7 +1,7 @@
 package com.michelin.kafkactl.command.config;
 
 import static com.michelin.kafkactl.mixin.UnmaskTokenMixin.MASKED;
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONTEXT;
 
 import com.michelin.kafkactl.config.KafkactlConfig;

--- a/src/main/java/com/michelin/kafkactl/command/config/ConfigGetContexts.java
+++ b/src/main/java/com/michelin/kafkactl/command/config/ConfigGetContexts.java
@@ -1,7 +1,7 @@
 package com.michelin.kafkactl.command.config;
 
 import static com.michelin.kafkactl.mixin.UnmaskTokenMixin.MASKED;
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONTEXT;
 
 import com.michelin.kafkactl.config.KafkactlConfig;

--- a/src/main/java/com/michelin/kafkactl/command/config/ConfigGetContexts.java
+++ b/src/main/java/com/michelin/kafkactl/command/config/ConfigGetContexts.java
@@ -1,7 +1,7 @@
 package com.michelin.kafkactl.command.config;
 
 import static com.michelin.kafkactl.mixin.UnmaskTokenMixin.MASKED;
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONTEXT;
 
 import com.michelin.kafkactl.config.KafkactlConfig;

--- a/src/main/java/com/michelin/kafkactl/model/Output.java
+++ b/src/main/java/com/michelin/kafkactl/model/Output.java
@@ -1,0 +1,22 @@
+package com.michelin.kafkactl.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Output.
+ */
+@Getter
+@AllArgsConstructor
+public enum Output {
+    YAML("yaml"),
+    YML("yml"),
+    TABLE("table");
+
+    private final String name;
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/com/michelin/kafkactl/service/FormatService.java
+++ b/src/main/java/com/michelin/kafkactl/service/FormatService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.michelin.kafkactl.config.KafkactlConfig;
 import com.michelin.kafkactl.model.ApiResource;
+import com.michelin.kafkactl.model.Output;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.model.Status;
 import com.michelin.kafkactl.model.format.AgoFormat;
@@ -21,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Tag;

--- a/src/main/java/com/michelin/kafkactl/service/FormatService.java
+++ b/src/main/java/com/michelin/kafkactl/service/FormatService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Tag;
@@ -33,8 +34,6 @@ import picocli.CommandLine.Model.CommandSpec;
  */
 @Singleton
 public class FormatService {
-    public static final String YAML = "yaml";
-    public static final String TABLE = "table";
     private final List<String> defaults =
         List.of("KIND:/kind", "NAME:/metadata/name", "AGE:/metadata/creationTimestamp%AGO");
 
@@ -50,10 +49,10 @@ public class FormatService {
      * @param output      The type of display
      * @param commandSpec The command spec used to print the output
      */
-    public void displayList(String kind, List<Resource> resources, String output, CommandSpec commandSpec) {
-        if (output.equals(TABLE)) {
+    public void displayList(String kind, List<Resource> resources, Output output, CommandSpec commandSpec) {
+        if (output.equals(Output.TABLE)) {
             printTable(kind, resources, commandSpec);
-        } else if (output.equals(YAML)) {
+        } else if (List.of(Output.YAML, Output.YML).contains(output)) {
             printYaml(resources, commandSpec);
         }
     }
@@ -65,7 +64,7 @@ public class FormatService {
      * @param output      The type of display
      * @param commandSpec The command spec used to print the output
      */
-    public void displaySingle(Resource resource, String output, CommandSpec commandSpec) {
+    public void displaySingle(Resource resource, Output output, CommandSpec commandSpec) {
         displayList(resource.getKind(), List.of(resource), output, commandSpec);
     }
 

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -1,7 +1,6 @@
 package com.michelin.kafkactl.service;
 
-import static com.michelin.kafkactl.service.FormatService.Output;
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECTOR;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECT_CLUSTER;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONSUMER_GROUP_RESET_OFFSET_RESPONSE;
@@ -12,6 +11,7 @@ import static com.michelin.kafkactl.util.constant.ResourceKind.VAULT_RESPONSE;
 import com.michelin.kafkactl.client.ClusterResourceClient;
 import com.michelin.kafkactl.client.NamespacedResourceClient;
 import com.michelin.kafkactl.model.ApiResource;
+import com.michelin.kafkactl.model.Output;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.model.SchemaCompatibility;
 import io.micronaut.core.annotation.Nullable;

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -1,6 +1,7 @@
 package com.michelin.kafkactl.service;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECTOR;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECT_CLUSTER;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONSUMER_GROUP_RESET_OFFSET_RESPONSE;
@@ -78,7 +79,7 @@ public class ResourceService {
                     String namespace,
                     String resourceName,
                     Map<String, String> search,
-                    String output,
+                    Output output,
                     CommandSpec commandSpec) {
         // Get a single kind of resources
         if (apiResources.size() == 1) {
@@ -386,7 +387,7 @@ public class ResourceService {
      * @param commandSpec The command that triggered the action
      * @return 0 if the command succeeded, 1 otherwise
      */
-    public int resetPassword(String namespace, String user, String output, CommandSpec commandSpec) {
+    public int resetPassword(String namespace, String user, Output output, CommandSpec commandSpec) {
         try {
             HttpResponse<Resource> response =
                 namespacedClient.resetPassword(namespace, user, loginService.getAuthorization());

--- a/src/test/java/com/michelin/kafkactl/command/ApiResourcesTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ApiResourcesTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.RESOURCE_DEFINITION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/michelin/kafkactl/command/ApiResourcesTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ApiResourcesTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.RESOURCE_DEFINITION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/michelin/kafkactl/command/ConnectorTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ConnectorTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CHANGE_CONNECTOR_STATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/michelin/kafkactl/command/ConnectorTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ConnectorTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CHANGE_CONNECTOR_STATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/michelin/kafkactl/command/GetTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/GetTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -93,20 +93,13 @@ class GetTest {
             .synchronizable(true)
             .build();
 
-        when(configService.isCurrentContextValid())
-            .thenReturn(true);
-        when(loginService.doAuthenticate(any(), anyBoolean()))
-            .thenReturn(true);
-        when(apiResourcesService.getResourceDefinitionByName(any()))
-            .thenReturn(Optional.of(apiResource));
-
         CommandLine cmd = new CommandLine(get);
         StringWriter sw = new StringWriter();
         cmd.setErr(new PrintWriter(sw));
 
         int code = cmd.execute("topics", "-o", "unknownOutputFormat");
         assertEquals(2, code);
-        assertTrue(sw.toString().contains("Invalid value unknownOutputFormat for option -o."));
+        assertTrue(sw.toString().contains("Invalid value for option '--output'"));
     }
 
     @Test

--- a/src/test/java/com/michelin/kafkactl/command/GetTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/GetTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/michelin/kafkactl/command/GetTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/GetTest.java
@@ -85,14 +85,6 @@ class GetTest {
 
     @Test
     void shouldNotGetWhenUnknownOutput() {
-        ApiResource apiResource = ApiResource.builder()
-            .kind("Topic")
-            .path("topics")
-            .names(List.of("topics", "topic", "to"))
-            .namespaced(true)
-            .synchronizable(true)
-            .build();
-
         CommandLine cmd = new CommandLine(get);
         StringWriter sw = new StringWriter();
         cmd.setErr(new PrintWriter(sw));

--- a/src/test/java/com/michelin/kafkactl/command/ResetPasswordTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ResetPasswordTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/michelin/kafkactl/command/ResetPasswordTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ResetPasswordTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -73,18 +73,13 @@ class ResetPasswordTest {
 
     @Test
     void shouldNotUpdateUserWhenUnknownOutput() {
-        when(configService.isCurrentContextValid())
-            .thenReturn(true);
-        when(loginService.doAuthenticate(any(), anyBoolean()))
-            .thenReturn(true);
-
         CommandLine cmd = new CommandLine(resetPassword);
         StringWriter sw = new StringWriter();
         cmd.setErr(new PrintWriter(sw));
 
         int code = cmd.execute("user", "-o", "unknownOutputFormat");
         assertEquals(2, code);
-        assertTrue(sw.toString().contains("Invalid value unknownOutputFormat for option -o."));
+        assertTrue(sw.toString().contains("Invalid value for option '--output'"));
     }
 
     @Test

--- a/src/test/java/com/michelin/kafkactl/command/SchemaTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/SchemaTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.SCHEMA_COMPATIBILITY_STATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/michelin/kafkactl/command/SchemaTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/SchemaTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.SCHEMA_COMPATIBILITY_STATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/michelin/kafkactl/command/auth/AuthInfoTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/auth/AuthInfoTest.java
@@ -1,7 +1,7 @@
 package com.michelin.kafkactl.command.auth;
 
 import static com.michelin.kafkactl.model.JwtContent.RoleBinding.Verb.GET;
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.AUTH_INFO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/michelin/kafkactl/command/auth/AuthInfoTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/auth/AuthInfoTest.java
@@ -1,7 +1,7 @@
 package com.michelin.kafkactl.command.auth;
 
 import static com.michelin.kafkactl.model.JwtContent.RoleBinding.Verb.GET;
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.AUTH_INFO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/michelin/kafkactl/command/config/ConfigCurrentContextTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/config/ConfigCurrentContextTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command.config;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;

--- a/src/test/java/com/michelin/kafkactl/command/config/ConfigCurrentContextTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/config/ConfigCurrentContextTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command.config;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;

--- a/src/test/java/com/michelin/kafkactl/command/config/ConfigGetContextsTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/config/ConfigGetContextsTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command.config;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;

--- a/src/test/java/com/michelin/kafkactl/command/config/ConfigGetContextsTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/config/ConfigGetContextsTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.command.config;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;

--- a/src/test/java/com/michelin/kafkactl/service/FormatServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/FormatServiceTest.java
@@ -1,8 +1,8 @@
 package com.michelin.kafkactl.service;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
-import static com.michelin.kafkactl.service.FormatService.Output.YAML;
-import static com.michelin.kafkactl.service.FormatService.Output.YML;
+import static com.michelin.kafkactl.model.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.YAML;
+import static com.michelin.kafkactl.model.Output.YML;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -171,7 +171,8 @@ class FormatServiceTest {
 
         formatService.displayList("RoleBinding", Collections.singletonList(resource), TABLE, cmd.getCommandSpec());
 
-        assertTrue(Pattern.compile("ROLE_BINDING\\s+GROUP\\s+VERBS\\s+RESOURCES").matcher(sw.toString()).find());
+        assertTrue(Pattern.compile("ROLE_BINDING\\s+GROUP\\s+VERBS\\s+RESOURCES")
+            .matcher(sw.toString()).find());
         assertTrue(Pattern.compile("roleBinding\\s+GROUP\\s+GET,POST,PUT,DELETE\\s+topics,acls,connectors")
             .matcher(sw.toString()).find());
     }
@@ -293,8 +294,10 @@ class FormatServiceTest {
 
         formatService.displaySingle(resource, TABLE, cmd.getCommandSpec());
 
-        assertTrue(Pattern.compile("TOPIC\\s+RETENTION\\s+POLICY\\s+AGE").matcher(sw.toString()).find());
-        assertTrue(Pattern.compile("prefix.topic\\s+1m\\s+delete").matcher(sw.toString()).find());
+        assertTrue(Pattern.compile("TOPIC\\s+RETENTION\\s+POLICY\\s+AGE")
+            .matcher(sw.toString()).find());
+        assertTrue(Pattern.compile("prefix.topic\\s+1m\\s+delete")
+            .matcher(sw.toString()).find());
 
     }
 

--- a/src/test/java/com/michelin/kafkactl/service/FormatServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/FormatServiceTest.java
@@ -298,7 +298,6 @@ class FormatServiceTest {
             .matcher(sw.toString()).find());
         assertTrue(Pattern.compile("prefix.topic\\s+1m\\s+delete")
             .matcher(sw.toString()).find());
-
     }
 
     @Test

--- a/src/test/java/com/michelin/kafkactl/service/FormatServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/FormatServiceTest.java
@@ -1,7 +1,8 @@
 package com.michelin.kafkactl.service;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
-import static com.michelin.kafkactl.service.FormatService.YAML;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.YAML;
+import static com.michelin.kafkactl.service.FormatService.Output.YML;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,6 +22,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
@@ -119,7 +121,7 @@ class FormatServiceTest {
         StringWriter sw = new StringWriter();
         cmd.setOut(new PrintWriter(sw));
 
-        formatService.displayList("Topic", Collections.singletonList(resource), YAML, cmd.getCommandSpec());
+        formatService.displayList("Topic", Collections.singletonList(resource), YML, cmd.getCommandSpec());
 
         assertTrue(sw.toString().contains("  name: prefix.topic"));
         assertTrue(sw.toString().contains("    retention.ms: '60000'"));
@@ -169,8 +171,9 @@ class FormatServiceTest {
 
         formatService.displayList("RoleBinding", Collections.singletonList(resource), TABLE, cmd.getCommandSpec());
 
-        assertTrue(sw.toString().contains("ROLE_BINDING  GROUP  VERBS                RESOURCES"));
-        assertTrue(sw.toString().contains("roleBinding   GROUP  GET,POST,PUT,DELETE  topics,acls,connectors"));
+        assertTrue(Pattern.compile("ROLE_BINDING\\s+GROUP\\s+VERBS\\s+RESOURCES").matcher(sw.toString()).find());
+        assertTrue(Pattern.compile("roleBinding\\s+GROUP\\s+GET,POST,PUT,DELETE\\s+topics,acls,connectors")
+            .matcher(sw.toString()).find());
     }
 
     @Test
@@ -290,8 +293,9 @@ class FormatServiceTest {
 
         formatService.displaySingle(resource, TABLE, cmd.getCommandSpec());
 
-        assertTrue(sw.toString().contains("TOPIC         RETENTION  POLICY  AGE"));
-        assertTrue(sw.toString().contains("prefix.topic  1m         delete"));
+        assertTrue(Pattern.compile("TOPIC\\s+RETENTION\\s+POLICY\\s+AGE").matcher(sw.toString()).find());
+        assertTrue(Pattern.compile("prefix.topic\\s+1m\\s+delete").matcher(sw.toString()).find());
+
     }
 
     @Test

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.service;
 
-import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
+import static com.michelin.kafkactl.model.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CHANGE_CONNECTOR_STATE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECTOR;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECT_CLUSTER;

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -1,6 +1,6 @@
 package com.michelin.kafkactl.service;
 
-import static com.michelin.kafkactl.service.FormatService.TABLE;
+import static com.michelin.kafkactl.service.FormatService.Output.TABLE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CHANGE_CONNECTOR_STATE;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECTOR;
 import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECT_CLUSTER;

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -274,7 +274,7 @@ class ResourceServiceTest {
             .thenReturn(List.of());
 
         int actual = resourceService.list(
-            List.of(apiResourceOne, apiResourceTwo), "namespace", TABLE, Map.of(), "*", cmd.getCommandSpec()
+            List.of(apiResourceOne, apiResourceTwo), "namespace", "*", Map.of(), TABLE, cmd.getCommandSpec()
         );
 
         assertEquals(0, actual);


### PR DESCRIPTION
In this PR, I made all the output options (`-o` or `--output`) in command line (like `kafkactl get topic -o yaml`) an `Output` enum type (the type defined in `FormatService`).

Picocli seems to be able to handle enum type and correctly throw errors if provided value not in the enum, so I removed all the `validateOutput()` methods.

Doc: https://picocli.info/#_built_in_types
Example of error thrown by Picocli:
![image](https://github.com/user-attachments/assets/206b8215-d058-4d9b-9d87-2cb0163030ff)

This also allows to use upper cases for the values `yml`, `yaml` and `table` like `kafkactl get topic -oTABLE`
