### PR TITLE
Add the possibility to import specific resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,29 +627,33 @@ The `import` command allows you to import unsynchronized resources between Ns4Ka
 cluster.
 
 ```console
-Usage: kafkactl import [-hv] [--dry-run] [-n=<optionalNamespace>] <resourceType>
+Usage: kafkactl import [-hv] [--dry-run] [-n=<optionalNamespace>] <resourceType> [<resourceName>]
 
 Description: Import non-synchronized resources.
 
 Parameters:
-      <resourceType>   Resource type.
+      <resourceType>     Resource type.
+      [<resourceName>]   Resource name or wildcard matching resource names.
 
 Options:
-      --dry-run        Does not persist resources. Validate only.
-  -h, --help           Show this help message and exit.
+      --dry-run          Does not persist resources. Validate only.
+  -h, --help             Show this help message and exit.
   -n, --namespace=<optionalNamespace>
-                       Override namespace defined in config or YAML resources.
-  -v, --verbose        Enable the verbose mode.
+                         Override namespace defined in config or YAML resources.
+  -v, --verbose          Enable the verbose mode.
 ```
 
 - `resourceType`: This option specifies the type of resource that you want to import, which can be either `topics`
-  or `connects`.
+  or `connectors`.
+- `resourceName`: This option specifies the name of the resource to import.
 
 Example(s):
 
 ```console
 kafkactl import topics
-kafkactl import connects
+kafkactl import topic myTopicName
+kafkactl import connectors
+kafkactl import connector myConnectorName
 ```
 
 ### Reset Offsets

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -119,9 +119,13 @@ public interface NamespacedResourceClient {
      * @param dryrun Is dry-run mode or not?
      * @return The list of imported resources
      */
-    @Post("{namespace}/{kind}/_/import{?dryrun}")
+    @Post("{namespace}/{kind}/_/import{?name,dryrun}")
     List<Resource> importResources(
-            String namespace, String kind, @Header("Authorization") String token, @QueryValue boolean dryrun);
+            String namespace,
+            String kind,
+            @Header("Authorization") String token,
+            @QueryValue String name,
+            @QueryValue boolean dryrun);
 
     /**
      * Delete records for a given topic.

--- a/src/main/java/com/michelin/kafkactl/command/Delete.java
+++ b/src/main/java/com/michelin/kafkactl/command/Delete.java
@@ -112,7 +112,7 @@ public class Delete extends DryRunHook {
                                 dryRun,
                                 commandSpec);
                     })
-                    .mapToInt(value -> Boolean.TRUE.equals(value) ? 0 : 1)
+                    .mapToInt(value -> value ? 0 : 1)
                     .sum();
 
             return errors > 0 ? 1 : 0;

--- a/src/main/java/com/michelin/kafkactl/command/Import.java
+++ b/src/main/java/com/michelin/kafkactl/command/Import.java
@@ -48,6 +48,13 @@ public class Import extends DryRunHook {
     @Parameters(index = "0", description = "Resource type.", arity = "1")
     public String resourceType;
 
+    @Parameters(
+            index = "1",
+            description = "Resource name or wildcard matching resource names.",
+            arity = "0..1",
+            defaultValue = "*")
+    public String resourceName;
+
     /**
      * Run the "get" command.
      *
@@ -56,7 +63,7 @@ public class Import extends DryRunHook {
     public Integer onAuthSuccess() {
         // Validate resourceType + custom type ALL
         List<ApiResource> apiResources = validateResourceType();
-        return resourceService.importAll(apiResources, getNamespace(), dryRun, commandSpec);
+        return resourceService.importAll(apiResources, getNamespace(), resourceName, dryRun, commandSpec);
     }
 
     /**

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -280,12 +280,13 @@ public class ResourceService {
      * @param commandSpec The command that triggered the action
      * @return 0 if the command succeed, 1 otherwise
      */
-    public int importAll(List<ApiResource> apiResources, String namespace, boolean dryRun, CommandSpec commandSpec) {
+    public int importAll(
+            List<ApiResource> apiResources, String namespace, String name, boolean dryRun, CommandSpec commandSpec) {
         int errors = apiResources.stream()
                 .map(apiResource -> {
                     try {
                         List<Resource> resources = namespacedClient.importResources(
-                                namespace, apiResource.getPath(), loginService.getAuthorization(), dryRun);
+                                namespace, apiResource.getPath(), loginService.getAuthorization(), name, dryRun);
                         if (!resources.isEmpty()) {
                             formatService.displayList(apiResource.getKind(), resources, TABLE, commandSpec);
                         } else {

--- a/src/test/java/com/michelin/kafkactl/command/ImportTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ImportTest.java
@@ -147,14 +147,40 @@ class ImportTest {
                 .build();
 
         when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.importAll(any(), any(), anyBoolean(), any())).thenReturn(0);
+        when(resourceService.importAll(any(), any(), any(), anyBoolean(), any()))
+                .thenReturn(0);
 
         CommandLine cmd = new CommandLine(importCmd);
 
         int code = cmd.execute("topic", "-n", "namespace");
         assertEquals(0, code);
         verify(resourceService)
-                .importAll(Collections.singletonList(apiResource), "namespace", false, cmd.getCommandSpec());
+                .importAll(Collections.singletonList(apiResource), "namespace", "*", false, cmd.getCommandSpec());
+    }
+
+    @Test
+    void shouldImportSpecificTopicResources() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+
+        ApiResource apiResource = ApiResource.builder()
+                .kind("Topic")
+                .path("topics")
+                .names(List.of("topics", "topic", "to"))
+                .namespaced(true)
+                .synchronizable(true)
+                .build();
+
+        when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
+        when(resourceService.importAll(any(), any(), any(), anyBoolean(), any()))
+                .thenReturn(0);
+
+        CommandLine cmd = new CommandLine(importCmd);
+
+        int code = cmd.execute("topic", "myTopic", "-n", "namespace");
+        assertEquals(0, code);
+        verify(resourceService)
+                .importAll(Collections.singletonList(apiResource), "namespace", "myTopic", false, cmd.getCommandSpec());
     }
 
     @Test
@@ -171,7 +197,8 @@ class ImportTest {
                 .build();
 
         when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.importAll(any(), any(), anyBoolean(), any())).thenReturn(0);
+        when(resourceService.importAll(any(), any(), any(), anyBoolean(), any()))
+                .thenReturn(0);
 
         CommandLine cmd = new CommandLine(importCmd);
         StringWriter sw = new StringWriter();
@@ -181,7 +208,7 @@ class ImportTest {
         assertEquals(0, code);
         assertTrue(sw.toString().contains("Dry run execution."));
         verify(resourceService)
-                .importAll(Collections.singletonList(apiResource), "namespace", true, cmd.getCommandSpec());
+                .importAll(Collections.singletonList(apiResource), "namespace", "*", true, cmd.getCommandSpec());
     }
 
     @Test
@@ -216,13 +243,15 @@ class ImportTest {
 
         when(apiResourcesService.listResourceDefinitions())
                 .thenReturn(List.of(apiResource, nonNamespacedApiResource, nonSyncApiResource));
-        when(resourceService.importAll(any(), any(), anyBoolean(), any())).thenReturn(0);
+        when(resourceService.importAll(any(), any(), any(), anyBoolean(), any()))
+                .thenReturn(0);
 
         CommandLine cmd = new CommandLine(importCmd);
 
         int code = cmd.execute("all");
         assertEquals(0, code);
         verify(resourceService)
-                .importAll(List.of(apiResource, nonNamespacedApiResource), "namespace", false, cmd.getCommandSpec());
+                .importAll(
+                        List.of(apiResource, nonNamespacedApiResource), "namespace", "*", false, cmd.getCommandSpec());
     }
 }

--- a/src/test/java/com/michelin/kafkactl/service/resource/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/resource/ResourceServiceTest.java
@@ -950,7 +950,7 @@ class ResourceServiceTest {
     }
 
     @Test
-    void shouldImportAllSuccess() {
+    void shouldImportAllResources() {
         ApiResource apiResource = ApiResource.builder()
                 .kind("Topic")
                 .path("topics")
@@ -971,11 +971,11 @@ class ResourceServiceTest {
 
         CommandLine cmd = new CommandLine(new Kafkactl());
 
-        when(namespacedClient.importResources(any(), any(), any(), anyBoolean()))
+        when(namespacedClient.importResources(any(), any(), any(), any(), anyBoolean()))
                 .thenReturn(Collections.singletonList(topicResource));
 
         int actual = resourceService.importAll(
-                Collections.singletonList(apiResource), "namespace", false, cmd.getCommandSpec());
+                Collections.singletonList(apiResource), "namespace", "*", false, cmd.getCommandSpec());
 
         assertEquals(0, actual);
         verify(formatService)
@@ -983,7 +983,7 @@ class ResourceServiceTest {
     }
 
     @Test
-    void shouldImportAllEmpty() {
+    void shouldImportNoResource() {
         ApiResource apiResource = ApiResource.builder()
                 .kind("Topic")
                 .path("topics")
@@ -996,18 +996,18 @@ class ResourceServiceTest {
         StringWriter sw = new StringWriter();
         cmd.setOut(new PrintWriter(sw));
 
-        when(namespacedClient.importResources(any(), any(), any(), anyBoolean()))
+        when(namespacedClient.importResources(any(), any(), any(), any(), anyBoolean()))
                 .thenReturn(Collections.emptyList());
 
         int actual = resourceService.importAll(
-                Collections.singletonList(apiResource), "namespace", false, cmd.getCommandSpec());
+                Collections.singletonList(apiResource), "namespace", any(), false, cmd.getCommandSpec());
 
         assertEquals(0, actual);
         assertTrue(sw.toString().contains("No topic to import."));
     }
 
     @Test
-    void shouldImportAllFail() {
+    void shouldNotImportAllResources() {
         ApiResource apiResource = ApiResource.builder()
                 .kind("Topic")
                 .path("topics")
@@ -1019,11 +1019,11 @@ class ResourceServiceTest {
         CommandLine cmd = new CommandLine(new Kafkactl());
 
         HttpClientResponseException exception = new HttpClientResponseException("error", HttpResponse.serverError());
-        when(namespacedClient.importResources(any(), any(), any(), anyBoolean()))
+        when(namespacedClient.importResources(any(), any(), any(), any(), anyBoolean()))
                 .thenThrow(exception);
 
         int actual = resourceService.importAll(
-                Collections.singletonList(apiResource), "namespace", false, cmd.getCommandSpec());
+                Collections.singletonList(apiResource), "namespace", "*", false, cmd.getCommandSpec());
 
         assertEquals(1, actual);
         verify(formatService).displayError(exception, cmd.getCommandSpec());

--- a/src/test/java/com/michelin/kafkactl/service/resource/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/resource/ResourceServiceTest.java
@@ -1000,7 +1000,7 @@ class ResourceServiceTest {
                 .thenReturn(Collections.emptyList());
 
         int actual = resourceService.importAll(
-                Collections.singletonList(apiResource), "namespace", any(), false, cmd.getCommandSpec());
+                Collections.singletonList(apiResource), "namespace", "*", false, cmd.getCommandSpec());
 
         assertEquals(0, actual);
         assertTrue(sw.toString().contains("No topic to import."));


### PR DESCRIPTION
This PR adds the possibility to import specific resources which are not synchronized from the cluster to Ns4kafka.

It implements the argument `resourceName` in the command line `kafkactl import <resources> <resourceName>` which can be the resource name or a wildcard string matching resource names.
Example of usage:
- `kafkactl import topic myPrefix.myTopic` would only import the topic `myPrefix.myTopic` if it exists on the cluster and is not known by Ns4kafka.
- `kafkactl import topic myPrefix.*-test` would import all the unsynchronized topics matching `myPrefix.*-test`.
