### PR TITLE
Add delete consumer group command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Commands:
   delete           Delete a resource.
   diff             Get differences between a new resource and a old resource.
   get              Get resources by resource type for the current namespace.
+  group            Interact with consumer groups.
   import           Import non-synchronized resources.
   reset-offsets    Reset consumer group offsets.
   schema           Interact with schemas.
@@ -548,6 +549,28 @@ kafkactl delete schema *
 kafkactl delete schema mySchema -V latest
 ```
 
+### Group
+
+The `group` command allows you to interact with consumer groups.
+
+```console
+Usage: kafkactl group [-h] [COMMAND]
+
+Description: Interact with consumer groups.
+
+Commands:
+  delete  Delete a consumer group.
+
+Options:
+  -h, --help   Show this help message and exit.
+```
+
+Example(s):
+
+```console
+kafkactl group delete myConsumerGroup
+```
+
 ### Diff
 
 The `diff` command allows you to compare a new YAML descriptor with the current one deployed in Ns4Kafka, allowing you
@@ -663,6 +686,32 @@ kafkactl import topics
 kafkactl import topic myTopicName
 kafkactl import connectors
 kafkactl import connector myConnectorName
+```
+
+### Group Delete
+
+The `group delete` command allows you to delete a consumer group.
+
+```console
+Usage: kafkactl group delete [-hv] [--dry-run] [-n=<optionalNamespace>] <group>
+
+Description: Delete a consumer group.
+
+Parameters:
+      <group>     Consumer group name.
+
+Options:
+      --dry-run   Does not persist resources. Validate only.
+  -h, --help      Show this help message and exit.
+  -n, --namespace=<optionalNamespace>
+                  Override namespace defined in config or YAML resources.
+  -v, --verbose   Enable the verbose mode.
+```
+
+Example(s):
+
+```console
+kafkactl group delete myConsumerGroup
 ```
 
 ### Reset Offsets

--- a/src/main/java/com/michelin/kafkactl/Kafkactl.java
+++ b/src/main/java/com/michelin/kafkactl/Kafkactl.java
@@ -34,6 +34,7 @@ import com.michelin.kafkactl.command.Schema;
 import com.michelin.kafkactl.command.auth.Auth;
 import com.michelin.kafkactl.command.config.Config;
 import com.michelin.kafkactl.command.connectcluster.ConnectCluster;
+import com.michelin.kafkactl.command.group.Group;
 import com.michelin.kafkactl.service.SystemService;
 import com.michelin.kafkactl.util.VersionProvider;
 import io.micronaut.configuration.picocli.PicocliRunner;
@@ -58,6 +59,7 @@ import picocli.CommandLine.Spec;
             Delete.class,
             Diff.class,
             Get.class,
+            Group.class,
             Import.class,
             ResetOffsets.class,
             Schema.class,

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -168,7 +168,7 @@ public interface NamespacedResourceClient {
      * @return The delete response
      */
     @Delete("{namespace}/consumer-groups/{consumerGroupName}{?dryrun}")
-    HttpResponse<?> deleteGroup(
+    HttpResponse<Void> deleteGroup(
             @Header("Authorization") String token,
             String namespace,
             String consumerGroupName,

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -159,6 +159,22 @@ public interface NamespacedResourceClient {
             @QueryValue boolean dryrun);
 
     /**
+     * Delete a consumer group.
+     *
+     * @param token The authentication token
+     * @param namespace The namespace
+     * @param consumerGroupName The consumer group
+     * @param dryrun Is dry run mode or not?
+     * @return The delete response
+     */
+    @Delete("{namespace}/consumer-groups/{consumerGroupName}{?dryrun}")
+    HttpResponse<?> deleteGroup(
+            @Header("Authorization") String token,
+            String namespace,
+            String consumerGroupName,
+            @QueryValue boolean dryrun);
+
+    /**
      * Change the state of a given connector.
      *
      * @param namespace The namespace

--- a/src/main/java/com/michelin/kafkactl/command/group/Group.java
+++ b/src/main/java/com/michelin/kafkactl/command/group/Group.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafkactl.command.group;
+
+import com.michelin.kafkactl.hook.HelpHook;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/** Group subcommand. */
+@Command(
+        name = "group",
+        subcommands = {GroupDelete.class},
+        headerHeading = "@|bold Usage|@:",
+        synopsisHeading = " ",
+        synopsisSubcommandLabel = "COMMAND",
+        descriptionHeading = "%n@|bold Description|@: ",
+        description = "Interact with consumer groups.",
+        parameterListHeading = "%n@|bold Parameters|@:%n",
+        optionListHeading = "%n@|bold Options|@:%n",
+        commandListHeading = "%n@|bold Commands|@:%n",
+        usageHelpAutoWidth = true)
+public class Group extends HelpHook {
+    @Spec
+    public CommandSpec commandSpec;
+}

--- a/src/main/java/com/michelin/kafkactl/command/group/GroupDelete.java
+++ b/src/main/java/com/michelin/kafkactl/command/group/GroupDelete.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafkactl.command.group;
+
+import com.michelin.kafkactl.hook.DryRunHook;
+import com.michelin.kafkactl.service.ResourceService;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** Delete consumer group subcommand. */
+@Command(
+        name = "delete",
+        headerHeading = "@|bold Usage|@:",
+        synopsisHeading = " ",
+        descriptionHeading = "%n@|bold Description|@: ",
+        description = "Delete a consumer group.",
+        parameterListHeading = "%n@|bold Parameters|@:%n",
+        optionListHeading = "%n@|bold Options|@:%n",
+        commandListHeading = "%n@|bold Commands|@:%n",
+        usageHelpAutoWidth = true)
+public class GroupDelete extends DryRunHook {
+    @Inject
+    @ReflectiveAccess
+    private ResourceService resourceService;
+
+    @Parameters(description = "Consumer group name.", arity = "1")
+    public String group;
+
+    /**
+     * Run the "group delete" command.
+     *
+     * @return The command return code
+     */
+    @Override
+    public Integer onAuthSuccess() {
+        return resourceService.deleteGroup(getNamespace(), group, dryRun, commandSpec);
+    }
+}

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -358,6 +358,36 @@ public class ResourceService {
     }
 
     /**
+     * Delete a consumer group.
+     *
+     * @param namespace The namespace
+     * @param group The consumer group
+     * @param dryRun Is dry run mode or not?
+     * @param commandSpec The command that triggered the action
+     * @return 0 if the command succeeded, 1 otherwise
+     */
+    public int deleteGroup(String namespace, String group, boolean dryRun, CommandSpec commandSpec) {
+        try {
+            HttpResponse<?> response = namespacedClient.deleteGroup(
+                    loginService.getAuthorization(), namespace, group, dryRun);
+
+            // Micronaut does not throw exception on 404, so produce a 404 manually
+            if (response.getStatus().equals(HttpStatus.NOT_FOUND)) {
+                throw new HttpClientResponseException(response.reason(), response);
+            }
+
+            commandSpec
+                    .commandLine()
+                    .getOut()
+                    .println(formatService.prettifyKind("ConsumerGroup") + " \"" + group + "\" deleted.");
+            return 0;
+        } catch (HttpClientResponseException exception) {
+            formatService.displayError(exception, "ConsumerGroup", group, commandSpec);
+            return 1;
+        }
+    }
+
+    /**
      * Change the state of a given connector.
      *
      * @param namespace The namespace

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -368,8 +368,8 @@ public class ResourceService {
      */
     public int deleteGroup(String namespace, String group, boolean dryRun, CommandSpec commandSpec) {
         try {
-            HttpResponse<?> response = namespacedClient.deleteGroup(
-                    loginService.getAuthorization(), namespace, group, dryRun);
+            HttpResponse<?> response =
+                    namespacedClient.deleteGroup(loginService.getAuthorization(), namespace, group, dryRun);
 
             // Micronaut does not throw exception on 404, so produce a 404 manually
             if (response.getStatus().equals(HttpStatus.NOT_FOUND)) {

--- a/src/test/java/com/michelin/kafkactl/command/group/GroupDeleteTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/group/GroupDeleteTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafkactl.command.group;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
+
+import com.michelin.kafkactl.Kafkactl;
+import com.michelin.kafkactl.property.KafkactlProperties;
+import com.michelin.kafkactl.service.ConfigService;
+import com.michelin.kafkactl.service.LoginService;
+import com.michelin.kafkactl.service.ResourceService;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import picocli.CommandLine;
+
+@ExtendWith(MockitoExtension.class)
+class GroupDeleteTest {
+    @Mock
+    LoginService loginService;
+
+    @Mock
+    ResourceService resourceService;
+
+    @Mock
+    ConfigService configService;
+
+    @Mock
+    KafkactlProperties kafkactlProperties;
+
+    @Mock
+    Kafkactl kafkactl;
+
+    @InjectMocks
+    GroupDelete groupDelete;
+
+    @Test
+    void shouldReturnInvalidCurrentContext() {
+        CommandLine cmd = new CommandLine(groupDelete);
+        StringWriter sw = new StringWriter();
+        cmd.setErr(new PrintWriter(sw));
+
+        when(configService.isCurrentContextValid()).thenReturn(false);
+
+        int code = cmd.execute("my-group");
+        assertEquals(1, code);
+        assertTrue(sw.toString()
+                .contains("No valid current context found. "
+                        + "Use \"kafkactl config use-context\" to set a valid context."));
+    }
+
+    @Test
+    void shouldNotDeleteWhenNotAuthenticated() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(false);
+
+        CommandLine cmd = new CommandLine(groupDelete);
+
+        int code = cmd.execute("my-group");
+        assertEquals(1, code);
+    }
+
+    @Test
+    void shouldDeleteDryRunSuccess() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+        when(kafkactlProperties.getCurrentNamespace()).thenReturn("namespace");
+        when(resourceService.deleteGroup(any(), any(), anyBoolean(), any())).thenReturn(0);
+
+        CommandLine cmd = new CommandLine(groupDelete);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        int code = cmd.execute("my-group", "--dry-run");
+        assertEquals(0, code);
+        assertTrue(sw.toString().contains("Dry run execution."));
+    }
+
+    @Test
+    void shouldDeleteSuccess() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+        when(kafkactlProperties.getCurrentNamespace()).thenReturn("namespace");
+        when(resourceService.deleteGroup(any(), any(), anyBoolean(), any())).thenReturn(0);
+
+        CommandLine cmd = new CommandLine(groupDelete);
+
+        int code = cmd.execute("my-group");
+        assertEquals(0, code);
+    }
+
+    @Test
+    void shouldDeleteFail() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+        when(kafkactlProperties.getCurrentNamespace()).thenReturn("namespace");
+        when(resourceService.deleteGroup(any(), any(), anyBoolean(), any())).thenReturn(1);
+
+        CommandLine cmd = new CommandLine(groupDelete);
+
+        int code = cmd.execute("my-group");
+        assertEquals(1, code);
+    }
+}

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -1183,7 +1183,11 @@ class ResourceServiceTest {
 
         assertEquals(1, actual);
         verify(formatService)
-                .displayError(any(HttpClientResponseException.class), eq("ConsumerGroup"), eq("group"), eq(cmd.getCommandSpec()));
+                .displayError(
+                        any(HttpClientResponseException.class),
+                        eq("ConsumerGroup"),
+                        eq("group"),
+                        eq(cmd.getCommandSpec()));
     }
 
     @Test

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -1159,6 +1159,47 @@ class ResourceServiceTest {
     }
 
     @Test
+    void shouldDeleteGroupSuccess() {
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        doCallRealMethod().when(formatService).prettifyKind(any());
+        when(namespacedClient.deleteGroup(any(), any(), any(), anyBoolean())).thenReturn(HttpResponse.noContent());
+
+        int actual = resourceService.deleteGroup("namespace", "group", false, cmd.getCommandSpec());
+
+        assertEquals(0, actual);
+        assertTrue(sw.toString().contains("Consumer group \"group\" deleted."));
+    }
+
+    @Test
+    void shouldDeleteGroupNotFound() {
+        CommandLine cmd = new CommandLine(new Kafkactl());
+
+        when(namespacedClient.deleteGroup(any(), any(), any(), anyBoolean())).thenReturn(HttpResponse.notFound());
+
+        int actual = resourceService.deleteGroup("namespace", "group", false, cmd.getCommandSpec());
+
+        assertEquals(1, actual);
+        verify(formatService)
+                .displayError(any(HttpClientResponseException.class), eq("ConsumerGroup"), eq("group"), eq(cmd.getCommandSpec()));
+    }
+
+    @Test
+    void shouldDeleteGroupFail() {
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        HttpClientResponseException exception = new HttpClientResponseException("error", HttpResponse.serverError());
+
+        when(namespacedClient.deleteGroup(any(), any(), any(), anyBoolean())).thenThrow(exception);
+
+        int actual = resourceService.deleteGroup("namespace", "group", false, cmd.getCommandSpec());
+
+        assertEquals(1, actual);
+        verify(formatService).displayError(exception, "ConsumerGroup", "group", cmd.getCommandSpec());
+    }
+
+    @Test
     void shouldChangeConnectorState() {
         Resource changeConnectorStateResource = Resource.builder()
                 .kind(CHANGE_CONNECTOR_STATE)


### PR DESCRIPTION
## Context

I wanted to add support for deleting a consumer group from `kafkactl` so users can perform this action directly from the CLI using the new Ns4Kafka endpoint.

## Proposed solution

I introduced a dedicated CLI flow for consumer-group deletion through:

`kafkactl group delete <groupName>`

The goal was to keep the command consistent with the existing command structure and make the deletion path straightforward for users.

## Implementation

I added a new `group` command with a `delete` subcommand and registered it in the main CLI entrypoint.

I then wired the command to the new Ns4Kafka endpoint:
`DELETE /api/namespaces/:namespace/consumer-groups/:consumer-group`

On the service side, I added the handling needed to:
- call the new endpoint
- support `--dry-run`
- return standard success and error messages aligned with the current CLI behavior

I also updated the README so the new command is documented alongside the existing commands.

## Tests

I added command-level tests for the new `group delete` flow and service-level tests for the API interaction.

## Remark

I kept the change intentionally small and aligned with the existing code style and command patterns already used in `kafkactl`.