### PR TITLE
Add warning handling for resource application responses

### DIFF
--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -215,6 +215,18 @@ public class ResourceService {
                                     ? " " + response.header("X-Ns4kafka-Result")
                                     : "")
                             + ".");
+
+            String warnings = response.header("X-Ns4kafka-Warnings");
+            if (warnings != null && !warnings.isBlank()) {
+                List<String> warningsList = Arrays.asList(warnings.split(","));
+                commandSpec
+                        .commandLine()
+                        .getErr()
+                        .println("The resource " + resource.getMetadata().getName() + " was applied with "
+                                + warningsList.size() + " warnings:");
+                warningsList.forEach(
+                        warning -> commandSpec.commandLine().getErr().println("- " + warning));
+            }
             return response;
         } catch (HttpClientResponseException e) {
             formatService.displayError(

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -673,6 +673,84 @@ class ResourceServiceTest {
     }
 
     @Test
+    void shouldApplyNamespacedResourceWithWarningsInResponse() {
+        Resource topicResource = Resource.builder()
+                .kind("Topic")
+                .apiVersion("v1")
+                .metadata(Resource.Metadata.builder()
+                        .name("prefix.topic")
+                        .creationTimestamp(Date.from(Instant.parse("2000-01-01T01:00:00.00Z")))
+                        .build())
+                .spec(Map.of())
+                .build();
+
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+
+        doCallRealMethod().when(formatService).prettifyKind(any());
+        when(namespacedClient.apply(any(), any(), any(), any(), anyBoolean()))
+                .thenReturn(HttpResponse.ok(topicResource)
+                        .header("X-Ns4kafka-Result", "created")
+                        .header("X-Ns4kafka-Warnings", "first warning,second warning"));
+
+        ApiResource apiResource = ApiResource.builder()
+                .kind("Topic")
+                .path("topics")
+                .names(List.of("topics", "topic", "to"))
+                .namespaced(true)
+                .synchronizable(true)
+                .build();
+
+        HttpResponse<Resource> actual =
+                resourceService.apply(apiResource, "namespace", topicResource, false, cmd.getCommandSpec());
+
+        assertEquals(HttpStatus.OK, actual.getStatus());
+        assertEquals(topicResource, actual.body());
+        assertTrue(out.toString().contains("Topic \"prefix.topic\" created."));
+        assertTrue(err.toString().contains("The resource prefix.topic was applied with 2 warnings:"));
+        assertTrue(err.toString().contains("- first warning"));
+        assertTrue(err.toString().contains("- second warning"));
+    }
+
+    @Test
+    void shouldApplyNamespacedResourceWithoutWarningOutputWhenWarningsHeaderBlank() {
+        Resource topicResource = Resource.builder()
+                .kind("Topic")
+                .apiVersion("v1")
+                .metadata(Resource.Metadata.builder()
+                        .name("prefix.topic")
+                        .creationTimestamp(Date.from(Instant.parse("2000-01-01T01:00:00.00Z")))
+                        .build())
+                .spec(Map.of())
+                .build();
+
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        StringWriter err = new StringWriter();
+        cmd.setErr(new PrintWriter(err));
+
+        doCallRealMethod().when(formatService).prettifyKind(any());
+        when(namespacedClient.apply(any(), any(), any(), any(), anyBoolean()))
+                .thenReturn(HttpResponse.ok(topicResource).header("X-Ns4kafka-Warnings", ""));
+
+        ApiResource apiResource = ApiResource.builder()
+                .kind("Topic")
+                .path("topics")
+                .names(List.of("topics", "topic", "to"))
+                .namespaced(true)
+                .synchronizable(true)
+                .build();
+
+        HttpResponse<Resource> actual =
+                resourceService.apply(apiResource, "namespace", topicResource, false, cmd.getCommandSpec());
+
+        assertEquals(HttpStatus.OK, actual.getStatus());
+        assertTrue(err.toString().isBlank());
+    }
+
+    @Test
     void shouldApplyNonNamespacedResource() {
         Resource topicResource = Resource.builder()
                 .kind("Topic")


### PR DESCRIPTION
## What changed

This PR updates warning-related behavior coverage for resource apply responses and aligns tests with the new warning output format. It's is linked to [this PR](https://github.com/michelin/ns4kafka/pull/790) on ns4Kafka

In `src/main/java/com/michelin/kafkactl/service/ResourceService.java`, warning output from `X-Ns4kafka-Warnings` is now rendered as:
- a summary line with warning count
- one bullet line per warning

In `src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java`, tests were updated accordingly:
- `shouldApplyNamespacedResourceWithWarningsInResponse` now asserts:
  - summary line (with warning count)
  - bullet-format warning lines
- `shouldApplyNamespacedResourceWithoutWarningOutputWhenWarningsHeaderBlank` now uses an empty header value (`""`) instead of whitespace-only (`"   "`), to avoid Micronaut header validation errors while still validating blank-warning behavior.

## Why

- Keeps unit tests aligned with the updated CLI warning format.
- Fixes a failing test caused by invalid HTTP header content (`0x20` at index 0) in test setup, not production logic.
- Preserves behavior checks for both:
  - warning output when header is present and non-blank
  - no warning output when header is blank.
