### PR TITLE
Add Bash/Zsh shell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Kafkactl enables the deployment of Kafka resources to Ns4Kafka using YAML descri
     * [Auth](#auth)
         * [Info](#info)
         * [Renew](#renew)
+    * [Completion](#completion)
     * [Config](#config)
         * [Current Context](#current-context)
         * [Get Contexts](#get-contexts)
@@ -207,6 +208,7 @@ Commands:
   api-resources    Print the supported API resources on the server.
   apply            Create or update a resource.
   auth             Interact with authentication.
+  completion       Generate bash/zsh completion script for kafkactl.
   config           Manage configuration.
   connect-cluster  Interact with connect clusters.
   connector        Interact with connectors.
@@ -327,6 +329,41 @@ kafkactl apply -f resource.yml
 ```
 
 The resources have to be described in YAML manifests.
+
+### Completion
+
+Kafkactl supports bash/zsh shell completion to help you quickly type commands and options.
+
+#### Requirements
+
+- **Bash**: Version 4.0 or higher
+    - On macOS, you may need to upgrade bash: `brew install bash`
+    - Bash completion package: `brew install bash-completion@2` (macOS) or `apt-get install bash-completion` (Ubuntu/Debian)
+- **Zsh**: Works with default zsh installation
+- **Kafkactl**: Must be installed and accessible in your PATH
+
+#### Setup
+
+**1. Enable it in your shell (for persistent setup):**
+```bash
+# For Bash - add to ~/.bashrc
+source <(kafkactl completion)
+
+# For Zsh - add to ~/.zshrc
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+source <(kafkactl completion)
+```
+
+**3. Reload your shell:**
+```bash
+source ~/.bashrc  # or source ~/.zshrc for zsh
+```
+
+**4. Test it:**
+```bash
+kafkactl <TAB>         # Shows all available commands
+```
 
 ### Config
 

--- a/src/main/java/com/michelin/kafkactl/Kafkactl.java
+++ b/src/main/java/com/michelin/kafkactl/Kafkactl.java
@@ -22,6 +22,7 @@ import static com.michelin.kafkactl.property.KafkactlProperties.KAFKACTL_CONFIG;
 
 import com.michelin.kafkactl.command.ApiResources;
 import com.michelin.kafkactl.command.Apply;
+import com.michelin.kafkactl.command.Completion;
 import com.michelin.kafkactl.command.Connector;
 import com.michelin.kafkactl.command.Delete;
 import com.michelin.kafkactl.command.DeleteRecords;
@@ -52,6 +53,7 @@ import picocli.CommandLine.Spec;
             ApiResources.class,
             Apply.class,
             Auth.class,
+            Completion.class,
             Config.class,
             ConnectCluster.class,
             Connector.class,

--- a/src/main/java/com/michelin/kafkactl/command/Completion.java
+++ b/src/main/java/com/michelin/kafkactl/command/Completion.java
@@ -54,7 +54,10 @@ public class Completion implements Callable<Integer> {
             commandSpec.commandLine().getOut().println(script);
             return 0;
         } catch (Exception e) {
-            commandSpec.commandLine().getErr().println("An error occurred while generating completion script: " + e.getMessage());
+            commandSpec
+                    .commandLine()
+                    .getErr()
+                    .println("An error occurred while generating completion script: " + e.getMessage());
             return 1;
         }
     }

--- a/src/main/java/com/michelin/kafkactl/command/Completion.java
+++ b/src/main/java/com/michelin/kafkactl/command/Completion.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafkactl.command;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import java.util.concurrent.Callable;
+import picocli.AutoComplete;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/** Completion subcommand to generate bash/zsh completion scripts. */
+@Command(
+        name = "completion",
+        headerHeading = "@|bold Usage|@:",
+        synopsisHeading = " ",
+        descriptionHeading = "%n@|bold Description|@: ",
+        description = "Generate bash/zsh completion script for kafkactl.",
+        parameterListHeading = "%n@|bold Parameters|@:%n",
+        optionListHeading = "%n@|bold Options|@:%n",
+        commandListHeading = "%n@|bold Commands|@:%n",
+        usageHelpAutoWidth = true,
+        mixinStandardHelpOptions = true)
+@ReflectiveAccess
+public class Completion implements Callable<Integer> {
+    @Spec
+    CommandSpec commandSpec;
+
+    /**
+     * Run the completion command.
+     *
+     * @return The command return code
+     */
+    @Override
+    public Integer call() {
+        try {
+            String script = AutoComplete.bash("kafkactl", commandSpec.root().commandLine());
+            commandSpec.commandLine().getOut().println(script);
+            return 0;
+        } catch (Exception e) {
+            commandSpec.commandLine().getErr().println("An error occurred while generating completion script: " + e.getMessage());
+            return 1;
+        }
+    }
+}

--- a/src/test/java/com/michelin/kafkactl/command/CompletionTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/CompletionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafkactl.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+/** Test for Completion command. */
+class CompletionTest {
+    @Test
+    void shouldGenerateCompletionScript() {
+        Completion completion = new Completion();
+        CommandLine cmd = new CommandLine(completion);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+        int code = cmd.execute();
+        assertEquals(0, code);
+        String output = sw.toString();
+        assertTrue(output.contains("_complete_kafkactl"));
+        assertTrue(output.contains("complete -F _complete_kafkactl"));
+        assertTrue(output.contains("kafkactl"));
+    }
+
+    @Test
+    void shouldShowHelpMessage() {
+        Completion completion = new Completion();
+        CommandLine cmd = new CommandLine(completion);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+        int code = cmd.execute("-h");
+        assertEquals(0, code);
+        String output = sw.toString();
+        assertTrue(output.contains("Generate bash/zsh completion script for kafkactl"));
+    }
+}


### PR DESCRIPTION
# Add Bash/Zsh Shell Completion Support

## Summary

Adds shell completion (tab-completion) for kafkactl commands, options, and arguments in bash and zsh.

## Motivation

Resolves #276 

## Changes

### Added
- `Completion` command that generates bash/zsh completion scripts
- Unit tests for the completion command
- Shell completion section in README with requirements

### Modified
- `Kafkactl.java` - Added completion as a subcommand
- `README.md` - Added completion documentation

## Usage

**Quick (current session only):**
```bash
source <(kafkactl completion)
```

**Persistent:**
```bash
echo "source <(kafkactl completion)" >> ~/.bashrc
source ~/.bashrc
```

**For Zsh, also add:**
```bash
autoload -U +X compinit && compinit
autoload -U +X bashcompinpt && bashcompinpt
```

**Test it:**
```bash
kafkactl <TAB>         # Shows all commands
```

<img width="278" height="347" alt="image" src="https://github.com/user-attachments/assets/6fd0440b-ffb8-46d4-bb5b-b3bf440fb12d" />

> I use [fzf](https://github.com/junegunn/fzf) along with [fzf-tab](https://github.com/aloxaf/fzf-tab) in my shell, this makes it look better 


## Implementation

- Uses [Picocli's built-in](https://picocli.info/autocomplete.html) `AutoComplete.bash()` utility
- Outputs script to stdout for maximum flexibility




