### PR TITLE
Add the possibility to force delete connect cluster and connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,7 @@ Please note that the resources are deleted instantly and cannot be recovered onc
 with the resource is permanently lost.
 
 ```console
-Usage: kafkactl delete [-hv] [--dry-run] [-c=<optionalContext>] [-n=<optionalNamespace>] ([<resourceType> <resourceName> [-V[=<version>]] [--execute]] | [[-f=<file>] [-R]])
-
+Usage: kafkactl delete [-hv] [--dry-run] [--force] [-n=<optionalNamespace>] ([<resourceType> <name> [-V[=<version>]]] | [[-f=<file>] [-R]])
 Description: Delete a resource.
 
 Parameters:
@@ -596,6 +595,7 @@ Options:
       --dry-run        Does not persist resources. Validate only.
       --execute        This option is mandatory to delete resources with wildcard.
   -f, --file=<file>    YAML file or directory containing resources to delete.
+      --force          Force deletion for supported resources such as connect clusters and connectors.
   -h, --help           Show this help message and exit.
   -n, --namespace=<optionalNamespace>
                        Override namespace defined in config or YAML resources.
@@ -611,6 +611,8 @@ Example(s):
 kafkactl delete -f directoryOfResources
 kafkactl delete -f resource.yml
 kafkactl delete topic myTopic
+kafkactl delete connector myConnector --force
+kafkactl delete connect-cluster myConnectCluster --force
 kafkactl delete topic *-test
 kafkactl delete schema *
 kafkactl delete schema mySchema -V latest

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -47,7 +47,7 @@ public interface NamespacedResourceClient {
      * @param dryrun Is dry-run mode or not?
      * @return The delete response
      */
-    @Delete("{namespace}/{kind}{?name,version,dryrun}")
+    @Delete("{namespace}/{kind}{?name,version,dryrun,force}")
     @Retryable(
             delay = "${kafkactl.retry.delay}",
             attempts = "${kafkactl.retry.attempt}",
@@ -59,7 +59,8 @@ public interface NamespacedResourceClient {
             @Header("Authorization") String token,
             @QueryValue String name,
             @Nullable @QueryValue String version,
-            @QueryValue boolean dryrun);
+            @QueryValue boolean dryrun,
+            @Nullable @QueryValue Boolean force);
 
     /**
      * Apply a given resource.

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -60,7 +60,7 @@ public interface NamespacedResourceClient {
             @QueryValue String name,
             @Nullable @QueryValue String version,
             @QueryValue boolean dryrun,
-            @Nullable @QueryValue Boolean force);
+            @QueryValue boolean force);
 
     /**
      * Apply a given resource.

--- a/src/main/java/com/michelin/kafkactl/command/Delete.java
+++ b/src/main/java/com/michelin/kafkactl/command/Delete.java
@@ -68,7 +68,7 @@ public class Delete extends DryRunHook {
 
     @Option(
             names = {"--force"},
-            description = "Force deletion for supported resources such as connect clusters and connectors.")
+            description = "Force delete resource from Ns4Kafka. Only for connector and connect cluster.")
     public boolean force;
 
     /**

--- a/src/main/java/com/michelin/kafkactl/command/Delete.java
+++ b/src/main/java/com/michelin/kafkactl/command/Delete.java
@@ -66,6 +66,11 @@ public class Delete extends DryRunHook {
     @ArgGroup(multiplicity = "1")
     public EitherOf config;
 
+    @Option(
+            names = {"--force"},
+            description = "Force deletion for supported resources such as connect clusters and connectors.")
+    public boolean force;
+
     /**
      * Run the "delete" command.
      *
@@ -109,6 +114,7 @@ public class Delete extends DryRunHook {
                                         ? spec.get(VERSION).toString()
                                         : null),
                                 dryRun,
+                                force,
                                 commandSpec);
                     })
                     .mapToInt(value -> value ? 0 : 1)

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -241,11 +241,21 @@ public class ResourceService {
             String name,
             @Nullable String version,
             boolean dryRun,
+            boolean force,
             CommandSpec commandSpec) {
         try {
+            Boolean forceDelete = force && List.of(CONNECTOR, CONNECT_CLUSTER).contains(apiResource.getKind())
+                    ? Boolean.TRUE
+                    : null;
             HttpResponse<List<Resource>> response = apiResource.isNamespaced()
                     ? namespacedClient.delete(
-                            namespace, apiResource.getPath(), loginService.getAuthorization(), name, version, dryRun)
+                            namespace,
+                            apiResource.getPath(),
+                            loginService.getAuthorization(),
+                            name,
+                            version,
+                            dryRun,
+                            forceDelete)
                     : nonNamespacedClient.delete(loginService.getAuthorization(), apiResource.getPath(), name, dryRun);
 
             // Micronaut does not throw exception on 404, so produce a 404 manually

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -244,9 +244,8 @@ public class ResourceService {
             boolean force,
             CommandSpec commandSpec) {
         try {
-            Boolean forceDelete = force && List.of(CONNECTOR, CONNECT_CLUSTER).contains(apiResource.getKind())
-                    ? Boolean.TRUE
-                    : null;
+            Boolean forceDelete =
+                    force && List.of(CONNECTOR, CONNECT_CLUSTER).contains(apiResource.getKind()) ? Boolean.TRUE : null;
             HttpResponse<List<Resource>> response = apiResource.isNamespaced()
                     ? namespacedClient.delete(
                             namespace,

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -244,8 +244,6 @@ public class ResourceService {
             boolean force,
             CommandSpec commandSpec) {
         try {
-            Boolean forceDelete =
-                    force && List.of(CONNECTOR, CONNECT_CLUSTER).contains(apiResource.getKind()) ? Boolean.TRUE : null;
             HttpResponse<List<Resource>> response = apiResource.isNamespaced()
                     ? namespacedClient.delete(
                             namespace,
@@ -254,7 +252,7 @@ public class ResourceService {
                             name,
                             version,
                             dryRun,
-                            forceDelete)
+                            force)
                     : nonNamespacedClient.delete(loginService.getAuthorization(), apiResource.getPath(), name, dryRun);
 
             // Micronaut does not throw exception on 404, so produce a 404 manually

--- a/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
@@ -320,7 +320,7 @@ class DeleteTest {
     }
 
     @Test
-    void shouldDeleteConnectorByNameWithForce() {
+    void shouldForceDeleteConnectorByName() {
         when(configService.isCurrentContextValid()).thenReturn(true);
         when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
 
@@ -346,7 +346,7 @@ class DeleteTest {
     }
 
     @Test
-    void shouldDeleteConnectClusterByNameWithForce() {
+    void shouldForceDeleteConnectClusterByName() {
         when(configService.isCurrentContextValid()).thenReturn(true);
         when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
 

--- a/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -242,7 +243,7 @@ class DeleteTest {
                 .build();
 
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -281,7 +282,7 @@ class DeleteTest {
                 .build();
 
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -307,7 +308,7 @@ class DeleteTest {
 
         when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -316,6 +317,58 @@ class DeleteTest {
 
         int code = cmd.execute("topic", "prefix.topic", "-n", "namespace");
         assertEquals(0, code);
+    }
+
+    @Test
+    void shouldDeleteConnectorByNameWithForce() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+
+        ApiResource apiResource = ApiResource.builder()
+                .kind("Connector")
+                .path("connectors")
+                .names(List.of("connectors", "connector", "co"))
+                .namespaced(true)
+                .synchronizable(true)
+                .build();
+
+        when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
+        when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
+                .thenReturn(true);
+
+        CommandLine cmd = new CommandLine(delete);
+
+        int code = cmd.execute("connector", "prefix.connector", "-n", "namespace", "--force");
+        assertEquals(0, code);
+        verify(resourceService)
+                .delete(any(), eq("namespace"), eq("prefix.connector"), eq(null), eq(false), eq(true), any());
+    }
+
+    @Test
+    void shouldDeleteConnectClusterByNameWithForce() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+
+        ApiResource apiResource = ApiResource.builder()
+                .kind("ConnectCluster")
+                .path("connect-clusters")
+                .names(List.of("connect-clusters", "connect-cluster", "cc"))
+                .namespaced(true)
+                .synchronizable(true)
+                .build();
+
+        when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
+        when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
+                .thenReturn(true);
+
+        CommandLine cmd = new CommandLine(delete);
+
+        int code = cmd.execute("connect-cluster", "my-cluster", "-n", "namespace", "--force");
+        assertEquals(0, code);
+        verify(resourceService)
+                .delete(any(), eq("namespace"), eq("my-cluster"), eq(null), eq(false), eq(true), any());
     }
 
     @Test
@@ -333,7 +386,7 @@ class DeleteTest {
 
         when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -369,7 +422,7 @@ class DeleteTest {
                 .build();
 
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -409,7 +462,7 @@ class DeleteTest {
                 .build();
 
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(false);
 
         CommandLine cmd = new CommandLine(delete);
@@ -463,7 +516,7 @@ class DeleteTest {
 
         when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -489,7 +542,7 @@ class DeleteTest {
         assertTrue(sw.toString()
                 .contains("Rerun the command with option --dry-run to see the resources that will be deleted."));
         assertTrue(sw.toString().contains("Rerun the command with option --execute to execute this operation."));
-        verify(resourceService, never()).delete(any(), any(), any(), any(), anyBoolean(), any());
+        verify(resourceService, never()).delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any());
     }
 
     @Test
@@ -507,7 +560,7 @@ class DeleteTest {
         assertTrue(sw.toString()
                 .contains("Rerun the command with option --dry-run to see the resources that will be deleted."));
         assertTrue(sw.toString().contains("Rerun the command with option --execute to execute this operation."));
-        verify(resourceService, never()).delete(any(), any(), any(), any(), anyBoolean(), any());
+        verify(resourceService, never()).delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any());
     }
 
     @Test
@@ -525,7 +578,7 @@ class DeleteTest {
 
         when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);
@@ -552,7 +605,7 @@ class DeleteTest {
 
         when(apiResourcesService.getResourceDefinitionByName(any())).thenReturn(Optional.of(apiResource));
         when(apiResourcesService.getResourceDefinitionByKind(any())).thenReturn(Optional.of(apiResource));
-        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), any()))
+        when(resourceService.delete(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(true);
 
         CommandLine cmd = new CommandLine(delete);

--- a/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/DeleteTest.java
@@ -367,8 +367,7 @@ class DeleteTest {
 
         int code = cmd.execute("connect-cluster", "my-cluster", "-n", "namespace", "--force");
         assertEquals(0, code);
-        verify(resourceService)
-                .delete(any(), eq("namespace"), eq("my-cluster"), eq(null), eq(false), eq(true), any());
+        verify(resourceService).delete(any(), eq("namespace"), eq("my-cluster"), eq(null), eq(false), eq(true), any());
     }
 
     @Test

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -814,7 +814,7 @@ class ResourceServiceTest {
         doCallRealMethod().when(formatService).prettifyKind(any());
 
         Resource deletedResource = Resource.builder()
-                .metadata(Metadata.builder().name("connector").build())
+                .metadata(Resource.Metadata.builder().name("connector").build())
                 .build();
 
         when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
@@ -852,7 +852,7 @@ class ResourceServiceTest {
         doCallRealMethod().when(formatService).prettifyKind(any());
 
         Resource deletedResource = Resource.builder()
-                .metadata(Metadata.builder().name("cluster").build())
+                .metadata(Resource.Metadata.builder().name("cluster").build())
                 .build();
 
         when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.eq;
@@ -720,7 +721,7 @@ class ResourceServiceTest {
                 .metadata(Resource.Metadata.builder().name("name").build())
                 .build();
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
                 .thenReturn(HttpResponse.ok(List.of(deletedResource)).header("X-Ns4kafka-Result", "created"));
 
         ApiResource apiResource = ApiResource.builder()
@@ -731,7 +732,7 @@ class ResourceServiceTest {
                 .synchronizable(true)
                 .build();
 
-        boolean actual = resourceService.delete(apiResource, "namespace", "name", null, false, cmd.getCommandSpec());
+        boolean actual = resourceService.delete(apiResource, "namespace", "name", null, false, false, cmd.getCommandSpec());
 
         assertTrue(actual);
         assertTrue(sw.toString().contains("Topic \"name\" deleted."));
@@ -753,7 +754,7 @@ class ResourceServiceTest {
                 .metadata(Resource.Metadata.builder().name("name2").build())
                 .build();
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
                 .thenReturn(HttpResponse.ok(List.of(deletedResource1, deletedResource2))
                         .header("X-Ns4kafka-Result", "created"));
 
@@ -765,7 +766,8 @@ class ResourceServiceTest {
                 .synchronizable(true)
                 .build();
 
-        boolean actual = resourceService.delete(apiResource, "namespace", "name*", null, false, cmd.getCommandSpec());
+        boolean actual =
+                resourceService.delete(apiResource, "namespace", "name*", null, false, false, cmd.getCommandSpec());
 
         assertTrue(actual);
         assertTrue(sw.toString().contains("Topic \"name1\" deleted."));
@@ -784,7 +786,7 @@ class ResourceServiceTest {
                 .metadata(Resource.Metadata.builder().name("name").build())
                 .build();
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
                 .thenReturn(HttpResponse.ok(List.of(deletedResource)).header("X-Ns4kafka-Result", "created"));
 
         ApiResource apiResource = ApiResource.builder()
@@ -796,10 +798,86 @@ class ResourceServiceTest {
                 .build();
 
         boolean actual =
-                resourceService.delete(apiResource, "namespace", "name", "latest", false, cmd.getCommandSpec());
+                resourceService.delete(apiResource, "namespace", "name", "latest", false, false, cmd.getCommandSpec());
 
         assertTrue(actual);
         assertTrue(sw.toString().contains("Topic \"name\" version latest deleted."));
+    }
+
+    @Test
+    void shouldForceDeleteConnector() {
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        doCallRealMethod().when(formatService).prettifyKind(any());
+
+        Resource deletedResource = Resource.builder()
+                .metadata(Metadata.builder().name("connector").build())
+                .build();
+
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+                .thenReturn(HttpResponse.ok(List.of(deletedResource)));
+
+        ApiResource apiResource = ApiResource.builder()
+                .kind(CONNECTOR)
+                .path("connectors")
+                .names(List.of("connectors", "connector", "co"))
+                .namespaced(true)
+                .synchronizable(true)
+                .build();
+
+        boolean actual =
+                resourceService.delete(apiResource, "namespace", "connector", null, false, true, cmd.getCommandSpec());
+
+        assertTrue(actual);
+        verify(namespacedClient)
+                .delete(
+                        eq("namespace"),
+                        eq("connectors"),
+                        any(),
+                        eq("connector"),
+                        isNull(),
+                        eq(false),
+                        eq(Boolean.TRUE));
+    }
+
+    @Test
+    void shouldForceDeleteConnectCluster() {
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        doCallRealMethod().when(formatService).prettifyKind(any());
+
+        Resource deletedResource = Resource.builder()
+                .metadata(Metadata.builder().name("cluster").build())
+                .build();
+
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+                .thenReturn(HttpResponse.ok(List.of(deletedResource)));
+
+        ApiResource apiResource = ApiResource.builder()
+                .kind(CONNECT_CLUSTER)
+                .path("connect-clusters")
+                .names(List.of("connect-clusters", "connect-cluster", "cc"))
+                .namespaced(true)
+                .synchronizable(true)
+                .build();
+
+        boolean actual =
+                resourceService.delete(apiResource, "namespace", "cluster", null, false, true, cmd.getCommandSpec());
+
+        assertTrue(actual);
+        verify(namespacedClient)
+                .delete(
+                        eq("namespace"),
+                        eq("connect-clusters"),
+                        any(),
+                        eq("cluster"),
+                        isNull(),
+                        eq(false),
+                        eq(Boolean.TRUE));
     }
 
     @Test
@@ -825,7 +903,7 @@ class ResourceServiceTest {
                 .synchronizable(true)
                 .build();
 
-        boolean actual = resourceService.delete(apiResource, "namespace", "name", null, false, cmd.getCommandSpec());
+        boolean actual = resourceService.delete(apiResource, "namespace", "name", null, false, false, cmd.getCommandSpec());
 
         assertTrue(actual);
         assertTrue(sw.toString().contains("Topic \"name\" deleted."));
@@ -859,7 +937,8 @@ class ResourceServiceTest {
                 .synchronizable(true)
                 .build();
 
-        boolean actual = resourceService.delete(apiResource, "namespace", "name*", null, false, cmd.getCommandSpec());
+        boolean actual =
+                resourceService.delete(apiResource, "namespace", "name*", null, false, false, cmd.getCommandSpec());
 
         assertTrue(actual);
         assertTrue(sw.toString().contains("Topic \"name1\" deleted."));
@@ -879,11 +958,11 @@ class ResourceServiceTest {
         CommandLine cmd = new CommandLine(new Kafkactl());
 
         HttpClientResponseException exception = new HttpClientResponseException("error", HttpResponse.serverError());
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
                 .thenThrow(exception);
 
         boolean actual =
-                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, cmd.getCommandSpec());
+                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
 
         assertFalse(actual);
         verify(formatService).displayError(exception, "Topic", "prefix.topic", cmd.getCommandSpec());
@@ -901,11 +980,11 @@ class ResourceServiceTest {
 
         CommandLine cmd = new CommandLine(new Kafkactl());
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
                 .thenReturn(HttpResponse.notFound());
 
         boolean actual =
-                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, cmd.getCommandSpec());
+                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
 
         assertFalse(actual);
         verify(formatService)
@@ -932,7 +1011,7 @@ class ResourceServiceTest {
         when(nonNamespacedClient.delete(any(), any(), any(), anyBoolean())).thenReturn(HttpResponse.notFound());
 
         boolean actual =
-                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, cmd.getCommandSpec());
+                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
 
         assertFalse(actual);
         verify(formatService)

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -721,7 +721,7 @@ class ResourceServiceTest {
                 .metadata(Resource.Metadata.builder().name("name").build())
                 .build();
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
                 .thenReturn(HttpResponse.ok(List.of(deletedResource)).header("X-Ns4kafka-Result", "created"));
 
         ApiResource apiResource = ApiResource.builder()
@@ -755,7 +755,7 @@ class ResourceServiceTest {
                 .metadata(Resource.Metadata.builder().name("name2").build())
                 .build();
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
                 .thenReturn(HttpResponse.ok(List.of(deletedResource1, deletedResource2))
                         .header("X-Ns4kafka-Result", "created"));
 
@@ -787,7 +787,7 @@ class ResourceServiceTest {
                 .metadata(Resource.Metadata.builder().name("name").build())
                 .build();
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
                 .thenReturn(HttpResponse.ok(List.of(deletedResource)).header("X-Ns4kafka-Result", "created"));
 
         ApiResource apiResource = ApiResource.builder()
@@ -817,7 +817,7 @@ class ResourceServiceTest {
                 .metadata(Resource.Metadata.builder().name("connector").build())
                 .build();
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
                 .thenReturn(HttpResponse.ok(List.of(deletedResource)));
 
         ApiResource apiResource = ApiResource.builder()
@@ -833,14 +833,7 @@ class ResourceServiceTest {
 
         assertTrue(actual);
         verify(namespacedClient)
-                .delete(
-                        eq("namespace"),
-                        eq("connectors"),
-                        any(),
-                        eq("connector"),
-                        isNull(),
-                        eq(false),
-                        eq(Boolean.TRUE));
+                .delete(eq("namespace"), eq("connectors"), any(), eq("connector"), isNull(), eq(false), eq(true));
     }
 
     @Test
@@ -855,7 +848,7 @@ class ResourceServiceTest {
                 .metadata(Resource.Metadata.builder().name("cluster").build())
                 .build();
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
                 .thenReturn(HttpResponse.ok(List.of(deletedResource)));
 
         ApiResource apiResource = ApiResource.builder()
@@ -871,14 +864,7 @@ class ResourceServiceTest {
 
         assertTrue(actual);
         verify(namespacedClient)
-                .delete(
-                        eq("namespace"),
-                        eq("connect-clusters"),
-                        any(),
-                        eq("cluster"),
-                        isNull(),
-                        eq(false),
-                        eq(Boolean.TRUE));
+                .delete(eq("namespace"), eq("connect-clusters"), any(), eq("cluster"), isNull(), eq(false), eq(true));
     }
 
     @Test
@@ -960,7 +946,7 @@ class ResourceServiceTest {
         CommandLine cmd = new CommandLine(new Kafkactl());
 
         HttpClientResponseException exception = new HttpClientResponseException("error", HttpResponse.serverError());
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
                 .thenThrow(exception);
 
         boolean actual = resourceService.delete(
@@ -982,7 +968,7 @@ class ResourceServiceTest {
 
         CommandLine cmd = new CommandLine(new Kafkactl());
 
-        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
+        when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
                 .thenReturn(HttpResponse.notFound());
 
         boolean actual = resourceService.delete(

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -732,7 +732,8 @@ class ResourceServiceTest {
                 .synchronizable(true)
                 .build();
 
-        boolean actual = resourceService.delete(apiResource, "namespace", "name", null, false, false, cmd.getCommandSpec());
+        boolean actual =
+                resourceService.delete(apiResource, "namespace", "name", null, false, false, cmd.getCommandSpec());
 
         assertTrue(actual);
         assertTrue(sw.toString().contains("Topic \"name\" deleted."));
@@ -903,7 +904,8 @@ class ResourceServiceTest {
                 .synchronizable(true)
                 .build();
 
-        boolean actual = resourceService.delete(apiResource, "namespace", "name", null, false, false, cmd.getCommandSpec());
+        boolean actual =
+                resourceService.delete(apiResource, "namespace", "name", null, false, false, cmd.getCommandSpec());
 
         assertTrue(actual);
         assertTrue(sw.toString().contains("Topic \"name\" deleted."));
@@ -961,8 +963,8 @@ class ResourceServiceTest {
         when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
                 .thenThrow(exception);
 
-        boolean actual =
-                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
+        boolean actual = resourceService.delete(
+                apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
 
         assertFalse(actual);
         verify(formatService).displayError(exception, "Topic", "prefix.topic", cmd.getCommandSpec());
@@ -983,8 +985,8 @@ class ResourceServiceTest {
         when(namespacedClient.delete(any(), any(), any(), any(), any(), anyBoolean(), any()))
                 .thenReturn(HttpResponse.notFound());
 
-        boolean actual =
-                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
+        boolean actual = resourceService.delete(
+                apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
 
         assertFalse(actual);
         verify(formatService)
@@ -1010,8 +1012,8 @@ class ResourceServiceTest {
 
         when(nonNamespacedClient.delete(any(), any(), any(), anyBoolean())).thenReturn(HttpResponse.notFound());
 
-        boolean actual =
-                resourceService.delete(apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
+        boolean actual = resourceService.delete(
+                apiResource, "namespace", "prefix.topic", null, false, false, cmd.getCommandSpec());
 
         assertFalse(actual);
         verify(formatService)


### PR DESCRIPTION
## Context

I wanted to add support for force deleting Connect Clusters and Connectors from `kafkactl` so Kafka admins can clean up stale resources directly from the CLI when Kafka Connect is unreachable or left in an incoherent state.

This change keeps `kafkactl` aligned with the corresponding Ns4Kafka behavior. For the Ns4Kafka server-side change, please refer to: https://github.com/michelin/ns4kafka/pull/752

## Proposed solution

I introduced support for a new `--force` option on the existing generic delete command so users can run:

`kafkactl delete connector <name> --force`

and

`kafkactl delete connect-cluster <name> --force`

The goal was to keep the CLI behavior consistent with the current command structure while exposing the new Ns4Kafka deletion capability in a simple way.

## Implementation

I extended the generic `delete` command to accept a `--force` option and propagated that flag through the existing delete flow.

On the API side, I updated the namespaced delete client so the `force` query parameter is sent to Ns4Kafka for supported deletions.

On the service side, I kept the change intentionally scoped so that:

- `Connector` and `ConnectCluster` deletions can use `force=true`
- existing delete behavior remains unchanged when `--force` is not used
- other resource kinds continue to use the standard delete flow

I also updated the README so the new option and examples are documented alongside the delete command.

## Tests

I added and updated tests to cover both the CLI and service layers.

## Remark

I kept the implementation small and aligned with the current `kafkactl` delete architecture by reusing the existing generic delete path instead of introducing new dedicated delete commands.