### PR TITLE
Enhance rendering of warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,8 +1192,8 @@ spec:
 
 ##### Validation Constraints
 
-Validations constraints enforce rules on the configuration of topics using `topicValidator` and connectors using
-`connectValidator`.
+Validation constraints define a list of properties that must adhere to rules specified by the `validation-type`.
+They can be defined for topics using `topicValidator` and for connectors using `connectValidator`.
 
 For topics, the following constraints are available:
 
@@ -1205,9 +1205,6 @@ For connectors, the following constraints are available:
 - `sourceValidationConstraints` applies to source connectors.
 - `sinkValidationConstraints` applies to sink connectors.
 - `classValidationConstraints` applies to connectors of a specific class.
-
-Validation constraints define a list of properties that must adhere to specific rules set by the `validation-type`.
-If the field is present, it will be validated; otherwise, it can be omitted without causing an error.
 
 ###### Range
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Kafkactl enables the deployment of Kafka resources to Ns4Kafka using YAML descri
             * [Inline](#inline)
     * [Administrator](#administrator)
         * [Namespace](#namespace)
-            * [Validation Constraints](#validation-constraints)
-                * [Topic](#topic-1)
-                * [Connector](#connector-3)
+            * [Topic Validation Constraints](#topic-validation-constraints)
+            * [Connector Validation Constraints](#connector-validation-constraints)
+            * [Validation Constraint Types](#validation-constraint-types)
                 * [Range](#range)
                 * [ValidList](#validlist)
                 * [ValidString](#validstring)
@@ -1192,14 +1192,10 @@ spec:
 - `spec.topicValidator` is a list of constraints for topics.
 - `spec.connectValidator` is a list of constraints for connectors.
 
-##### Validation Constraints
+##### Topic Validation Constraints
 
-Validation constraints define a list of properties that must adhere to rules specified by the `validation-type`.
-They can be defined for topics using `topicValidator` and for connectors using `connectValidator`.
-
-###### Topic
-
-Topic validation constraints applied to all topics using `spec.topicValidator.validationConstraints`. 
+Topic validation constraints define a list of topic properties that must adhere to rules specified by the `validation-type`.
+They apply to all topics using `spec.topicValidator.validationConstraints`. 
 
 ```yml
 topicValidator:
@@ -1213,9 +1209,10 @@ The `property` field can be any topic configuration property, or:
 - `partitions` for the number of partitions
 - `replication.factor` for the replication factor
 
-###### Connector
+##### Connector Validation Constraints
 
-Connector validation constraints are applied using one of the following:
+Connector validation constraints define a list of connector properties that must adhere to rules specified by the `validation-type`.
+They are applied using one of the following:
 
 - `spec.connectValidator.validationConstraints` applies to all connectors.
 - `spec.connectValidator.sourceValidationConstraints` applies to source connectors.
@@ -1241,6 +1238,10 @@ connectValidator:
 
 The `property` field can be any connector configuration property.
 The `connector-class` field can be any valid connector class, such as `io.confluent.connect.jdbc.JdbcSinkConnector`.
+
+##### Validation Constraint Types
+
+Multiple types of validation constraints are supported.
 
 ###### Range
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Kafkactl enables the deployment of Kafka resources to Ns4Kafka using YAML descri
                 * [ValidString](#validstring)
                 * [NonEmptyString](#nonemptystring)
                 * [ContainsList](#containslist)
+                * [RegexPattern](#regexpattern)
                 * [CompositeValidator](#compositevalidator)
         * [ACL Owner-Typed](#acl-owner-typed)
         * [Role Binding](#role-binding)
@@ -1206,7 +1207,6 @@ For connectors, the following constraints are available:
 - `classValidationConstraints` applies to connectors of a specific class.
 
 Validation constraints define a list of properties that must adhere to specific rules set by the `validation-type`.
-Constraints can be made optional by setting the `optional` attribute to `true`.
 If the field is present, it will be validated; otherwise, it can be omitted without causing an error.
 
 ###### Range
@@ -1218,9 +1218,15 @@ topicValidator:
   validationConstraints:
     partitions:
       validation-type: Range
+      optional: false
       min: 1
       max: 6
 ```
+
+The parameters of the `Range` validation type are:
+- `min` (optional): The minimum allowed value for the property.
+- `max` (optional): The maximum allowed value for the property.
+- `optional` (default: `false`): A boolean that indicates whether the property is optional. If set to `true`, the property can be omitted without causing a validation error.
 
 ###### ValidList
 
@@ -1237,6 +1243,10 @@ topicValidator:
         - compact
 ```
 
+The parameters of the `ValidList` validation type are:
+- `validStrings`: A list of valid strings that each item in the comma-separated list must match.
+- `optional` (default: `false`): A boolean that indicates whether the property is optional. If set to `true`, the property can be omitted without causing a validation error.
+
 ###### ValidString
 
 Ensures that the property is a string that matches one of the values specified in the `validStrings` list.
@@ -1246,10 +1256,15 @@ connectValidator:
   validationConstraints:
     connector.class:
       validation-type: ValidString
+      optional: false
       validStrings:
         - io.confluent.connect.jdbc.JdbcSinkConnector
         - io.confluent.connect.jdbc.JdbcSourceConnector
 ```
+
+The parameters of the `ValidString` validation type are:
+- `validStrings`: A list of valid strings that the property must match.
+- `optional` (default: `false`): A boolean that indicates whether the property is optional. If set to `true`, the property can be omitted without causing a validation error.
 
 ###### NonEmptyString
 
@@ -1276,6 +1291,26 @@ connectValidator:
         - ns1.topic2
 ```
 
+The parameters of the `ContainsList` validation type are:
+- `mandatoryStrings`: A list of strings that must be included in the comma-separated list.
+
+###### RegexPattern
+
+Ensures that the property matches a specified regular expression pattern.
+
+```yml
+topicValidator:
+  validationConstraints:
+    name:
+      validation-type: RegexPattern
+      pattern: "^[a-zA-Z0-9._-]+$"
+      strict: false
+```
+
+The parameters of the `RegexPattern` validation type are:
+- `pattern`: A regular expression that the property must match.
+- `strict` (default: `false`): A boolean that indicates whether the regular expression should be applied strictly. If set to `true`, the validation will fail. If set to `false`, the validation will pass throwing a warning.
+
 ###### CompositeValidator
 
 Ensures that the property satisfies multiple validation rules. The property is valid only if it meets all specified
@@ -1293,6 +1328,9 @@ connectValidator:
             - io.confluent.connect.jdbc.JdbcSinkConnector
             - io.confluent.connect.jdbc.JdbcSourceConnector
 ```
+
+The parameters of the `CompositeValidator` validation type are:
+- `validators`: A list of validation rules that the property must satisfy.
 
 #### ACL Owner-typed
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Kafkactl enables the deployment of Kafka resources to Ns4Kafka using YAML descri
     * [Administrator](#administrator)
         * [Namespace](#namespace)
             * [Validation Constraints](#validation-constraints)
+                * [Topic](#topic-1)
+                * [Connector](#connector-3)
                 * [Range](#range)
                 * [ValidList](#validlist)
                 * [ValidString](#validstring)
@@ -1195,16 +1197,50 @@ spec:
 Validation constraints define a list of properties that must adhere to rules specified by the `validation-type`.
 They can be defined for topics using `topicValidator` and for connectors using `connectValidator`.
 
-For topics, the following constraints are available:
+###### Topic
 
-- `validationConstraints` applies to all topics.
+Topic validation constraints applied to all topics using `spec.topicValidator.validationConstraints`. 
 
-For connectors, the following constraints are available:
+```yml
+topicValidator:
+  validationConstraints:
+    <property>:
+      validation-type: <validation-type>
+```
 
-- `validationConstraints` applies to all connectors.
-- `sourceValidationConstraints` applies to source connectors.
-- `sinkValidationConstraints` applies to sink connectors.
-- `classValidationConstraints` applies to connectors of a specific class.
+The `property` field can be any topic configuration property, or: 
+- `name` for the topic name
+- `partitions` for the number of partitions
+- `replication.factor` for the replication factor
+
+###### Connector
+
+Connector validation constraints are applied using one of the following:
+
+- `spec.connectValidator.validationConstraints` applies to all connectors.
+- `spec.connectValidator.sourceValidationConstraints` applies to source connectors.
+- `spec.connectValidator.sinkValidationConstraints` applies to sink connectors.
+- `spec.connectValidator.classValidationConstraints` applies to connectors of a specific class.
+
+```yml
+connectValidator:
+  validationConstraints:
+    <property>:
+      validation-type: <validation-type>
+  sourceValidationConstraints:
+    <property>:
+      validation-type: <validation-type>
+  sinkValidationConstraints:
+    <property>:
+      validation-type: <validation-type>
+  classValidationConstraints:
+    <connector-class>:
+      <property>:
+        validation-type: <validation-type>
+```
+
+The `property` field can be any connector configuration property.
+The `connector-class` field can be any valid connector class, such as `io.confluent.connect.jdbc.JdbcSinkConnector`.
 
 ###### Range
 

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -54,6 +54,8 @@ import picocli.CommandLine.ParameterException;
 /** Resource service. */
 @Singleton
 public class ResourceService {
+    public static final String HEADER_RESULT = "X-Ns4kafka-Result";
+    public static final String HEADER_WARNINGS = "X-Ns4kafka-Warnings";
     public static final String REFERENCES_FIELD = "references";
     public static final String SCHEMA_FIELD = "schema";
     public static final String SCHEMA_FILE_FIELD = "schemaFile";
@@ -206,7 +208,7 @@ public class ResourceService {
                     : nonNamespacedClient.apply(
                             loginService.getAuthorization(), apiResource.getPath(), resource, dryRun);
 
-            String headerWarning = response.header("X-Ns4kafka-Warnings");
+            String headerWarning = response.header(HEADER_WARNINGS);
             if (StringUtils.isNotEmpty(headerWarning)) {
                 List<String> warnings = Arrays.asList(headerWarning.split(","));
                 commandSpec
@@ -214,9 +216,7 @@ public class ResourceService {
                         .getOut()
                         .println(formatService.prettifyKind(response.body().getKind())
                                 + " \"" + response.body().getMetadata().getName() + "\""
-                                + (response.header("X-Ns4kafka-Result") != null
-                                        ? " " + response.header("X-Ns4kafka-Result")
-                                        : "")
+                                + (response.header(HEADER_RESULT) != null ? " " + response.header(HEADER_RESULT) : "")
                                 + " with " + warnings.size() + (warnings.size() > 1 ? " warnings:" : " warning:"));
                 warnings.forEach(warning -> commandSpec.commandLine().getOut().println("- " + warning));
             } else {
@@ -225,9 +225,7 @@ public class ResourceService {
                         .getOut()
                         .println(formatService.prettifyKind(response.body().getKind())
                                 + " \"" + response.body().getMetadata().getName() + "\""
-                                + (response.header("X-Ns4kafka-Result") != null
-                                        ? " " + response.header("X-Ns4kafka-Result")
-                                        : "")
+                                + (response.header(HEADER_RESULT) != null ? " " + response.header(HEADER_RESULT) : "")
                                 + ".");
             }
 

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -206,27 +206,31 @@ public class ResourceService {
                     : nonNamespacedClient.apply(
                             loginService.getAuthorization(), apiResource.getPath(), resource, dryRun);
 
-            commandSpec
-                    .commandLine()
-                    .getOut()
-                    .println(formatService.prettifyKind(response.body().getKind())
-                            + " \"" + response.body().getMetadata().getName() + "\""
-                            + (response.header("X-Ns4kafka-Result") != null
-                                    ? " " + response.header("X-Ns4kafka-Result")
-                                    : "")
-                            + ".");
-
-            String warnings = response.header("X-Ns4kafka-Warnings");
-            if (warnings != null && !warnings.isBlank()) {
-                List<String> warningsList = Arrays.asList(warnings.split(","));
+            String headerWarning = response.header("X-Ns4kafka-Warnings");
+            if (StringUtils.isNotEmpty(headerWarning)) {
+                List<String> warnings = Arrays.asList(headerWarning.split(","));
                 commandSpec
                         .commandLine()
-                        .getErr()
-                        .println("The resource " + resource.getMetadata().getName() + " was applied with "
-                                + warningsList.size() + " warnings:");
-                warningsList.forEach(
-                        warning -> commandSpec.commandLine().getErr().println("- " + warning));
+                        .getOut()
+                        .println(formatService.prettifyKind(response.body().getKind())
+                                + " \"" + response.body().getMetadata().getName() + "\""
+                                + (response.header("X-Ns4kafka-Result") != null
+                                        ? " " + response.header("X-Ns4kafka-Result")
+                                        : "")
+                                + " with " + warnings.size() + (warnings.size() > 1 ? " warnings:" : " warning:"));
+                warnings.forEach(warning -> commandSpec.commandLine().getOut().println("- " + warning));
+            } else {
+                commandSpec
+                        .commandLine()
+                        .getOut()
+                        .println(formatService.prettifyKind(response.body().getKind())
+                                + " \"" + response.body().getMetadata().getName() + "\""
+                                + (response.header("X-Ns4kafka-Result") != null
+                                        ? " " + response.header("X-Ns4kafka-Result")
+                                        : "")
+                                + ".");
             }
+
             return response;
         } catch (HttpClientResponseException e) {
             formatService.displayError(

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -710,10 +710,10 @@ class ResourceServiceTest {
 
         assertEquals(HttpStatus.OK, actual.getStatus());
         assertEquals(topicResource, actual.body());
-        assertTrue(out.toString().contains("Topic \"prefix.topic\" created."));
-        assertTrue(err.toString().contains("The resource prefix.topic was applied with 2 warnings:"));
-        assertTrue(err.toString().contains("- first warning"));
-        assertTrue(err.toString().contains("- second warning"));
+        assertTrue(out.toString().contains("Topic \"prefix.topic\" created with 2 warnings:"));
+        assertTrue(out.toString().contains("- first warning"));
+        assertTrue(out.toString().contains("- second warning"));
+        assertTrue(err.toString().isBlank());
     }
 
     @Test


### PR DESCRIPTION
This pull request updates the documentation and improves how resource warnings are handled and displayed in the `ResourceService`. The documentation now provides clearer explanations and parameter details for validation constraints, including the new `RegexPattern` validator. The `ResourceService` has been refactored to display warnings in a more user-friendly way, and related tests have been updated accordingly.

**Documentation improvements:**

* Added the `RegexPattern` validation type to the documentation, including usage example and parameter descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1291-R1310)
* Clarified the purpose and parameters of all validation constraints, adding explicit parameter lists for `Range`, `ValidList`, `ValidString`, `ContainsList`, and `CompositeValidator`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1194-R1196) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1208-L1211) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1218-R1227) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1243-R1246) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1256-R1265) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1329-R1331)

**ResourceService enhancements:**

* Introduced constants `HEADER_RESULT` and `HEADER_WARNINGS` for header names to improve maintainability.
* Refactored warning handling: warnings are now displayed on standard output with a clear count and list, and the resource application message is unified. Previously, warnings were printed to standard error.

**Test updates:**

* Updated `ResourceServiceTest` to match the new warning output format and ensure warnings are printed to standard output, not standard error.