### PR TITLE
Support external consumer groups  listing for namespace-owned topics- cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,14 +756,18 @@ kafkactl group delete myConsumerGroup
 
 The `list` command allows you to list the consumer groups owned by the current namespace.
 
+Use the `--external` option to list the consumer groups consuming topics owned by the current namespace but not owned by
+it.
+
 ```console
-Usage: kafkactl group list [-hv] [-c=<optionalContext>] [-n=<optionalNamespace>] [-o=<output>]
+Usage: kafkactl group list [-ehv] [-c=<optionalContext>] [-n=<optionalNamespace>] [-o=<output>]
 
 Description: List all consumer groups for the current namespace.
 
 Options:
   -c, --context=<optionalContext>
                   Override context defined in config.
+  -e, --external  List all consumer groups consuming topics owned by the current namespace.
   -h, --help      Show this help message and exit.
   -n, --namespace=<optionalNamespace>
                   Override namespace defined in config or YAML resources.
@@ -777,6 +781,7 @@ Example(s):
 ```console
 kafkactl group list
 kafkactl group list -o yaml
+kafkactl group list --external
 ```
 
 ### Import

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -186,6 +186,16 @@ public interface NamespacedResourceClient {
     List<Resource> listGroups(@Header("Authorization") String token, String namespace);
 
     /**
+     * List all external consumer groups consuming topics owned by a namespace.
+     *
+     * @param token The authentication token
+     * @param namespace The namespace
+     * @return The list of external consumer groups
+     */
+    @Get("{namespace}/consumer-groups/external")
+    List<Resource> listExternalGroups(@Header("Authorization") String token, String namespace);
+
+    /**
      * Change the state of a given connector.
      *
      * @param namespace The namespace

--- a/src/main/java/com/michelin/kafkactl/command/group/GroupList.java
+++ b/src/main/java/com/michelin/kafkactl/command/group/GroupList.java
@@ -47,6 +47,11 @@ public class GroupList extends AuthenticatedHook {
             defaultValue = "table")
     public Output output;
 
+    @Option(
+            names = {"-e", "--external"},
+            description = "List all consumer groups consuming topics owned by the current namespace.")
+    public boolean external;
+
     /**
      * Run the "group list" command.
      *
@@ -54,6 +59,6 @@ public class GroupList extends AuthenticatedHook {
      */
     @Override
     public Integer onAuthSuccess() {
-        return resourceService.listGroups(getNamespace(), output, commandSpec);
+        return resourceService.listGroups(getNamespace(), external, output, commandSpec);
     }
 }

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -413,13 +413,16 @@ public class ResourceService {
      * List all consumer groups for a namespace.
      *
      * @param namespace The namespace
+     * @param external List external consumer groups consuming topics owned by the namespace
      * @param output The output format
      * @param commandSpec The command that triggered the action
      * @return 0 if the command succeeded, 1 otherwise
      */
-    public int listGroups(String namespace, Output output, CommandSpec commandSpec) {
+    public int listGroups(String namespace, boolean external, Output output, CommandSpec commandSpec) {
         try {
-            List<Resource> resources = namespacedClient.listGroups(loginService.getAuthorization(), namespace);
+            List<Resource> resources = external
+                    ? namespacedClient.listExternalGroups(loginService.getAuthorization(), namespace)
+                    : namespacedClient.listGroups(loginService.getAuthorization(), namespace);
             if (!resources.isEmpty()) {
                 formatService.displayList(resources.getFirst().getKind(), resources, output, commandSpec);
             } else {

--- a/src/test/java/com/michelin/kafkactl/command/group/GroupListTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/group/GroupListTest.java
@@ -103,25 +103,52 @@ class GroupListTest {
         when(configService.isCurrentContextValid()).thenReturn(true);
         when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
         when(kafkactlProperties.getCurrentNamespace()).thenReturn("namespace");
-        when(resourceService.listGroups(any(), any(), any())).thenReturn(0);
+        when(resourceService.listGroups(any(), anyBoolean(), any(), any())).thenReturn(0);
 
         CommandLine cmd = new CommandLine(groupList);
 
         int code = cmd.execute();
         assertEquals(0, code);
-        verify(resourceService).listGroups("namespace", TABLE, cmd.getCommandSpec());
+        verify(resourceService).listGroups("namespace", false, TABLE, cmd.getCommandSpec());
     }
 
     @Test
     void shouldListGroupsWithProvidedNamespaceAndOutput() {
         when(configService.isCurrentContextValid()).thenReturn(true);
         when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
-        when(resourceService.listGroups(any(), any(), any())).thenReturn(0);
+        when(resourceService.listGroups(any(), anyBoolean(), any(), any())).thenReturn(0);
 
         CommandLine cmd = new CommandLine(groupList);
 
         int code = cmd.execute("-n", "namespace", "-o", "yaml");
         assertEquals(0, code);
-        verify(resourceService).listGroups("namespace", YAML, cmd.getCommandSpec());
+        verify(resourceService).listGroups("namespace", false, YAML, cmd.getCommandSpec());
+    }
+
+    @Test
+    void shouldListExternalGroupsUsingCurrentNamespace() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+        when(kafkactlProperties.getCurrentNamespace()).thenReturn("namespace");
+        when(resourceService.listGroups(any(), anyBoolean(), any(), any())).thenReturn(0);
+
+        CommandLine cmd = new CommandLine(groupList);
+
+        int code = cmd.execute("-e");
+        assertEquals(0, code);
+        verify(resourceService).listGroups("namespace", true, TABLE, cmd.getCommandSpec());
+    }
+
+    @Test
+    void shouldListExternalGroupsWithProvidedNamespaceAndOutput() {
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+        when(resourceService.listGroups(any(), anyBoolean(), any(), any())).thenReturn(0);
+
+        CommandLine cmd = new CommandLine(groupList);
+
+        int code = cmd.execute("-n", "namespace", "-o", "yaml", "--external");
+        assertEquals(0, code);
+        verify(resourceService).listGroups("namespace", true, YAML, cmd.getCommandSpec());
     }
 }

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -1364,7 +1364,30 @@ class ResourceServiceTest {
 
         when(namespacedClient.listGroups(any(), any())).thenReturn(Collections.singletonList(groupResource));
 
-        int actual = resourceService.listGroups("namespace", TABLE, cmd.getCommandSpec());
+        int actual = resourceService.listGroups("namespace", false, TABLE, cmd.getCommandSpec());
+
+        assertEquals(0, actual);
+        verify(formatService)
+                .displayList("ConsumerGroup", Collections.singletonList(groupResource), TABLE, cmd.getCommandSpec());
+    }
+
+    @Test
+    void shouldListExternalGroupsSuccess() {
+        Resource groupResource = Resource.builder()
+                .kind("ConsumerGroup")
+                .apiVersion("v1")
+                .metadata(Resource.Metadata.builder()
+                        .name("group")
+                        .creationTimestamp(Date.from(Instant.parse("2000-01-01T01:00:00.00Z")))
+                        .build())
+                .spec(Map.of())
+                .build();
+
+        CommandLine cmd = new CommandLine(new Kafkactl());
+
+        when(namespacedClient.listExternalGroups(any(), any())).thenReturn(Collections.singletonList(groupResource));
+
+        int actual = resourceService.listGroups("namespace", true, TABLE, cmd.getCommandSpec());
 
         assertEquals(0, actual);
         verify(formatService)
@@ -1379,7 +1402,21 @@ class ResourceServiceTest {
 
         when(namespacedClient.listGroups(any(), any())).thenReturn(Collections.emptyList());
 
-        int actual = resourceService.listGroups("namespace", TABLE, cmd.getCommandSpec());
+        int actual = resourceService.listGroups("namespace", false, TABLE, cmd.getCommandSpec());
+
+        assertEquals(0, actual);
+        assertTrue(sw.toString().contains("No consumer group to display."));
+    }
+
+    @Test
+    void shouldListExternalGroupsWhenEmpty() {
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        when(namespacedClient.listExternalGroups(any(), any())).thenReturn(Collections.emptyList());
+
+        int actual = resourceService.listGroups("namespace", true, TABLE, cmd.getCommandSpec());
 
         assertEquals(0, actual);
         assertTrue(sw.toString().contains("No consumer group to display."));
@@ -1392,7 +1429,20 @@ class ResourceServiceTest {
 
         when(namespacedClient.listGroups(any(), any())).thenThrow(exception);
 
-        int actual = resourceService.listGroups("namespace", TABLE, cmd.getCommandSpec());
+        int actual = resourceService.listGroups("namespace", false, TABLE, cmd.getCommandSpec());
+
+        assertEquals(1, actual);
+        verify(formatService).displayError(exception, cmd.getCommandSpec());
+    }
+
+    @Test
+    void shouldListExternalGroupsFail() {
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        HttpClientResponseException exception = new HttpClientResponseException("error", HttpResponse.serverError());
+
+        when(namespacedClient.listExternalGroups(any(), any())).thenThrow(exception);
+
+        int actual = resourceService.listGroups("namespace", true, TABLE, cmd.getCommandSpec());
 
         assertEquals(1, actual);
         verify(formatService).displayError(exception, cmd.getCommandSpec());


### PR DESCRIPTION
## Context

This is the second feature of the consumer-group listing epic. The goal is to let users monitor the Kafka
applications running on the topics their namespace owns (lags, consumers, etc.) directly from `kafkactl`.

The first feature of this epic — listing the consumer groups **owned** by the current namespace — was delivered in
[kafkactl#351](https://github.com/michelin/kafkactl/pull/351).

This PR adds the complementary capability: listing the **external** consumer groups (i.e. groups not owned by the
namespace) that consume topics the namespace owns. The Ns4Kafka side of this feature was implemented in
[ns4kafka#804](https://github.com/michelin/ns4kafka/pull/804), which exposes a dedicated
`GET /api/namespaces/{namespace}/consumer-groups/external` endpoint.

## Proposed solution

I extended the existing `group list` command with an `--external` (`-e`) option, keeping the CLI consistent with the listing flow introduced in the first feature:

```console
kafkactl group list --external
```

When the flag is set, the command lists the external consumer groups consuming topics owned by the current
namespace; otherwise it keeps its existing behavior of listing the namespace-owned consumer groups.

## Implementation

- Added a new client binding `listExternalGroups` in `NamespacedResourceClient`, wired to the new Ns4Kafka endpoint
  `GET {namespace}/consumer-groups/external`.
- Updated `ResourceService.listGroups` to take an `external` flag and route the call to either the standard or the
  external endpoint, reusing the same display and error-handling logic to avoid duplication.
- Added the `-e, --external` option to the `group list` command (`GroupList`) and passed it through to the service.
- Updated the README to document the new option alongside an example.

## Tests

- `ResourceServiceTest`: added service-level tests covering the external listing path (success, empty result, and
  failure), and updated the existing owned-group tests for the new method signature.
- `GroupListTest`: added command-level tests verifying the `--external` flag is correctly forwarded to the service,
  for both the current namespace and an explicitly provided namespace/output.
