### PR TITLE
Add connector stop command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Usage: kafkactl connector [-hv] [-c=<optionalContext>] [-n=<optionalNamespace>] 
 Description: Interact with connectors.
 
 Parameters:
-  <action>          Action to perform (pause, resume, restart, stop).
+      <action>          Action to perform (pause, resume, restart, stop).
       <connectors>...   Connector names separated by space or "all" for all connectors.
 
 Options:

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Usage: kafkactl connector [-hv] [-c=<optionalContext>] [-n=<optionalNamespace>] 
 Description: Interact with connectors.
 
 Parameters:
-      <action>          Action to perform (pause, resume, restart).
+  <action>          Action to perform (pause, resume, restart, stop).
       <connectors>...   Connector names separated by space or "all" for all connectors.
 
 Options:
@@ -541,7 +541,7 @@ Options:
   -v, --verbose         Enable the verbose mode.
 ```
 
-- `action`: This option specifies the action to execute, which can be `pause`, `resume`, `restart`
+- `action`: This option specifies the action to execute, which can be `pause`, `resume`, `restart`, `stop`
 - `connectors`: This option specifies the list of connector names separated by space or "all" for all connectors.
 
 Example(s):
@@ -550,6 +550,7 @@ Example(s):
 kafkactl connector pause myConnector
 kafkactl connector resume myConnector
 kafkactl connector restart myConnector
+kafkactl connector stop myConnector
 ```
 
 ### Delete Records

--- a/src/main/java/com/michelin/kafkactl/command/Connector.java
+++ b/src/main/java/com/michelin/kafkactl/command/Connector.java
@@ -124,7 +124,8 @@ public class Connector extends AuthenticatedHook {
     public enum ConnectorAction {
         PAUSE("pause"),
         RESUME("resume"),
-        RESTART("restart");
+        RESTART("restart"),
+        STOP("stop");
 
         private final String name;
 

--- a/src/test/java/com/michelin/kafkactl/command/ConnectorTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/ConnectorTest.java
@@ -140,8 +140,17 @@ class ConnectorTest {
 
         CommandLine cmd = new CommandLine(connector);
 
-        int code = cmd.execute("pause", "my-connector", "-n", "namespace");
+        int code = cmd.execute("stop", "my-connector", "-n", "namespace");
         assertEquals(0, code);
+        verify(resourceService)
+                .changeConnectorState(
+                        eq("namespace"),
+                        eq("my-connector"),
+                        argThat(changeConnectorStateRequest -> changeConnectorStateRequest
+                                .getSpec()
+                                .get("action")
+                                .equals("stop")),
+                        eq(cmd.getCommandSpec()));
         verify(formatService)
                 .displayList(
                         eq(CHANGE_CONNECTOR_STATE),


### PR DESCRIPTION
## Context

I wanted to add support for stopping a Kafka Connect connector from `kafkactl` so users can perform this action directly from the CLI through the Ns4Kafka connector state change flow.

This change depends on the Ns4Kafka implementation added in https://github.com/michelin/ns4kafka/pull/817.

## Proposed solution

I extended the existing connector action flow to support:

`kafkactl connector stop <connectorName>`

The goal was to keep the command consistent with the current connector action model already used for `pause`, `resume`, and `restart`, .
## Implementation

I added `STOP` to the `ConnectorAction` enum so the CLI accepts `stop` as a valid connector action.

I then wired the command through the existing connector state change request flow already used by the other connector lifecycle operations.

On the client side, this keeps the implementation aligned with the current Ns4Kafka API behavior, where connector stop is supported through the shared connector state change endpoint rather than a dedicated endpoint.

I also updated the README so the new action is documented alongside the existing connector actions.

## Tests

I updated command-level coverage for the connector command to verify that `stop` is accepted and that the generated request carries the expected connector state action.