### PR TITLE
Add support for altering and partially resetting connector offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,48 @@ kafkactl connector restart myConnector
 kafkactl connector stop myConnector
 ```
 
+#### Alter Offsets
+
+The `alter-offsets` command allows you to alter or partially reset the offsets of a connector.
+
+```console
+Usage: kafkactl connector alter-offsets [-hv] [-c=<optionalContext>] -f=<file> [-n=<optionalNamespace>]
+                                        <connector>
+
+Description: Alter or partially reset connector offsets.
+
+Parameters:
+      <connector>   Connector name.
+
+Options:
+  -c, --context=<optionalContext>
+                        Override context defined in config.
+  -f, --file=<file>     YAML file containing the connector offsets payload.
+  -h, --help            Show this help message and exit.
+  -n, --namespace=<optionalNamespace>
+                        Override namespace defined in config or YAML resources.
+  -v, --verbose         Enable the verbose mode.
+```
+
+The payload uses the Kafka Connect alter offsets format. Set `offset` to `null` to reset only the selected partition, or provide an offset map to alter it.
+
+```yaml
+offsets:
+  - partition:
+      filename: /data/input.txt
+    offset:
+      position: 100
+  - partition:
+      filename: /data/other.txt
+    offset: null
+```
+
+Example:
+
+```console
+kafkactl connector alter-offsets myConnector -f offsets.yaml
+```
+
 #### Reset Offsets
 
 The `reset-offsets` command allows you to fully resets the offsets of a connector.

--- a/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
+++ b/src/main/java/com/michelin/kafkactl/client/NamespacedResourceClient.java
@@ -19,6 +19,7 @@
 package com.michelin.kafkactl.client;
 
 import com.michelin.kafkactl.model.Resource;
+import com.michelin.kafkactl.model.request.ConnectorOffsets;
 import com.michelin.kafkactl.model.request.DeleteResourceRequest;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
@@ -26,6 +27,7 @@ import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Patch;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.annotation.RequestBean;
@@ -252,6 +254,24 @@ public interface NamespacedResourceClient {
             includes = ReadTimeoutException.class)
     HttpResponse<Resource> resetConnectorOffsets(
             String namespace, String connector, @Header("Authorization") String token);
+
+    /**
+     * Alter offsets for a given connector.
+     *
+     * @param namespace The namespace
+     * @param connector The connector to alter offsets for
+     * @param offsets The offsets payload
+     * @param token The auth token
+     * @return The alter offsets response
+     */
+    @Patch("{namespace}/connectors/{connector}/offsets")
+    @Retryable(
+            delay = "${kafkactl.retry.delay}",
+            attempts = "${kafkactl.retry.attempt}",
+            multiplier = "${kafkactl.retry.multiplier}",
+            includes = ReadTimeoutException.class)
+    HttpResponse<Resource> alterConnectorOffsets(
+            String namespace, String connector, @Body ConnectorOffsets offsets, @Header("Authorization") String token);
 
     /**
      * List all available connect clusters for vaulting.

--- a/src/main/java/com/michelin/kafkactl/command/connector/Connector.java
+++ b/src/main/java/com/michelin/kafkactl/command/connector/Connector.java
@@ -42,7 +42,7 @@ import picocli.CommandLine.Parameters;
 /** Connectors subcommand. */
 @Command(
         name = "connector",
-        subcommands = {ConnectorResetOffsets.class},
+        subcommands = {ConnectorAlterOffsets.class, ConnectorResetOffsets.class},
         headerHeading = "@|bold Usage|@:",
         synopsisHeading = " ",
         descriptionHeading = "%n@|bold Description|@: ",

--- a/src/main/java/com/michelin/kafkactl/command/connector/ConnectorAlterOffsets.java
+++ b/src/main/java/com/michelin/kafkactl/command/connector/ConnectorAlterOffsets.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafkactl.command.connector;
+
+import static com.michelin.kafkactl.model.Output.TABLE;
+import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECTOR_RESET_OFFSETS_RESPONSE;
+
+import com.michelin.kafkactl.hook.AuthenticatedHook;
+import com.michelin.kafkactl.model.Resource;
+import com.michelin.kafkactl.model.request.ConnectorOffsets;
+import com.michelin.kafkactl.service.FormatService;
+import com.michelin.kafkactl.service.ResourceService;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import jakarta.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/** Alter connector offsets subcommand. */
+@Command(
+        name = "alter-offsets",
+        headerHeading = "@|bold Usage|@:",
+        synopsisHeading = " ",
+        descriptionHeading = "%n@|bold Description|@: ",
+        description = "Alter or partially reset connector offsets.",
+        parameterListHeading = "%n@|bold Parameters|@:%n",
+        optionListHeading = "%n@|bold Options|@:%n",
+        commandListHeading = "%n@|bold Commands|@:%n",
+        usageHelpAutoWidth = true)
+public class ConnectorAlterOffsets extends AuthenticatedHook {
+    @Inject
+    @ReflectiveAccess
+    private ResourceService resourceService;
+
+    @Inject
+    @ReflectiveAccess
+    private FormatService formatService;
+
+    @Parameters(index = "0", description = "Connector name.")
+    public String connector;
+
+    @Option(
+            names = {"-f", "--file"},
+            description = "YAML file containing the connector offsets payload.",
+            required = true)
+    public File file;
+
+    @Override
+    public Integer onAuthSuccess() throws IOException {
+        ConnectorOffsets offsets = new Yaml(new Constructor(ConnectorOffsets.class, new LoaderOptions()))
+                .load(Files.readString(file.toPath()));
+
+        return resourceService
+                .alterConnectorOffsets(getNamespace(), connector, offsets, commandSpec)
+                .map(this::displayResponse)
+                .orElse(1);
+    }
+
+    private int displayResponse(Resource response) {
+        formatService.displayList(CONNECTOR_RESET_OFFSETS_RESPONSE, List.of(response), TABLE, commandSpec);
+        return 0;
+    }
+}

--- a/src/main/java/com/michelin/kafkactl/model/request/ConnectorOffsets.java
+++ b/src/main/java/com/michelin/kafkactl/model/request/ConnectorOffsets.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafkactl.model.request;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Connector offsets alteration request. */
+@Data
+@ReflectiveAccess
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConnectorOffsets {
+    private List<ConnectorOffset> offsets;
+
+    /** A connector partition and its new offset. */
+    @Data
+    @ReflectiveAccess
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ConnectorOffset {
+        private Map<String, Object> partition;
+        private Map<String, Object> offset;
+    }
+}

--- a/src/main/java/com/michelin/kafkactl/service/ResourceService.java
+++ b/src/main/java/com/michelin/kafkactl/service/ResourceService.java
@@ -33,6 +33,7 @@ import com.michelin.kafkactl.model.ApiResource;
 import com.michelin.kafkactl.model.Output;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.model.SubjectCompatibility;
+import com.michelin.kafkactl.model.request.ConnectorOffsets;
 import com.michelin.kafkactl.model.request.DeleteResourceRequest;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
@@ -471,6 +472,32 @@ public class ResourceService {
             }
 
             return Optional.of(resource);
+        } catch (HttpClientResponseException exception) {
+            formatService.displayError(exception, CONNECTOR, connector, commandSpec);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Alter offsets for a given connector.
+     *
+     * @param namespace The namespace
+     * @param connector The connector name
+     * @param offsets The offsets payload
+     * @param commandSpec The command that triggered the action
+     * @return The resource
+     */
+    public Optional<Resource> alterConnectorOffsets(
+            String namespace, String connector, ConnectorOffsets offsets, CommandSpec commandSpec) {
+        try {
+            HttpResponse<Resource> response = namespacedClient.alterConnectorOffsets(
+                    namespace, connector, offsets, loginService.getAuthorization());
+
+            if (response.getStatus().equals(HttpStatus.NOT_FOUND)) {
+                throw new HttpClientResponseException(response.reason(), response);
+            }
+
+            return response.getBody();
         } catch (HttpClientResponseException exception) {
             formatService.displayError(exception, CONNECTOR, connector, commandSpec);
             return Optional.empty();

--- a/src/test/java/com/michelin/kafkactl/command/connector/ConnectorAlterOffsetsTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/connector/ConnectorAlterOffsetsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafkactl.command.connector;
+
+import static com.michelin.kafkactl.model.Output.TABLE;
+import static com.michelin.kafkactl.util.constant.ResourceKind.CONNECTOR_RESET_OFFSETS_RESPONSE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.michelin.kafkactl.model.Resource;
+import com.michelin.kafkactl.property.KafkactlProperties;
+import com.michelin.kafkactl.service.ConfigService;
+import com.michelin.kafkactl.service.FormatService;
+import com.michelin.kafkactl.service.LoginService;
+import com.michelin.kafkactl.service.ResourceService;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import picocli.CommandLine;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectorAlterOffsetsTest {
+    @Mock
+    LoginService loginService;
+
+    @Mock
+    KafkactlProperties kafkactlProperties;
+
+    @Mock
+    ResourceService resourceService;
+
+    @Mock
+    FormatService formatService;
+
+    @Mock
+    ConfigService configService;
+
+    @InjectMocks
+    ConnectorAlterOffsets connectorAlterOffsets;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldAlterConnectorOffsets() throws IOException {
+        Path offsetsFile = writeOffsetsFile();
+        Resource response = Resource.builder()
+                .kind(CONNECTOR_RESET_OFFSETS_RESPONSE)
+                .metadata(Resource.Metadata.builder().name("my-connector").build())
+                .status(Map.of("code", "RESET"))
+                .build();
+
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+        when(resourceService.alterConnectorOffsets(any(), any(), any(), any())).thenReturn(Optional.of(response));
+
+        CommandLine cmd = new CommandLine(connectorAlterOffsets);
+        int code = cmd.execute("my-connector", "-f", offsetsFile.toString(), "-n", "namespace");
+
+        assertEquals(0, code);
+        verify(resourceService)
+                .alterConnectorOffsets(
+                        eq("namespace"),
+                        eq("my-connector"),
+                        argThat(request -> request.getOffsets().size() == 1
+                                && request.getOffsets()
+                                        .getFirst()
+                                        .getPartition()
+                                        .equals(Map.of("kafka_topic", "topic1", "kafka_partition", 0))
+                                && request.getOffsets().getFirst().getOffset() == null),
+                        eq(cmd.getCommandSpec()));
+        verify(formatService)
+                .displayList(CONNECTOR_RESET_OFFSETS_RESPONSE, List.of(response), TABLE, cmd.getCommandSpec());
+    }
+
+    @Test
+    void shouldReturnFailureWhenResponseIsEmpty() throws IOException {
+        Path offsetsFile = writeOffsetsFile();
+
+        when(configService.isCurrentContextValid()).thenReturn(true);
+        when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);
+        when(resourceService.alterConnectorOffsets(any(), any(), any(), any())).thenReturn(Optional.empty());
+
+        CommandLine cmd = new CommandLine(connectorAlterOffsets);
+        int code = cmd.execute("my-connector", "-f", offsetsFile.toString(), "-n", "namespace");
+
+        assertEquals(1, code);
+    }
+
+    private Path writeOffsetsFile() throws IOException {
+        return Files.writeString(tempDir.resolve("offsets.yaml"), """
+                offsets:
+                  - partition:
+                      kafka_topic: topic1
+                      kafka_partition: 0
+                    offset: null
+                """);
+    }
+}

--- a/src/test/java/com/michelin/kafkactl/command/connector/ConnectorTest.java
+++ b/src/test/java/com/michelin/kafkactl/command/connector/ConnectorTest.java
@@ -115,6 +115,18 @@ class ConnectorTest {
     }
 
     @Test
+    void shouldDisplayAlterOffsetsHelpWithoutParentParameters() {
+        CommandLine cmd = new CommandLine(connector);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        int code = cmd.execute("alter-offsets", "--help");
+
+        assertEquals(0, code);
+        assertTrue(sw.toString().contains("Alter or partially reset connector offsets."));
+    }
+
+    @Test
     void shouldNotChangeStateWhenEmptyConnectorsList() {
         when(configService.isCurrentContextValid()).thenReturn(true);
         when(loginService.doAuthenticate(any(), anyBoolean())).thenReturn(true);

--- a/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
+++ b/src/test/java/com/michelin/kafkactl/service/ResourceServiceTest.java
@@ -48,6 +48,7 @@ import com.michelin.kafkactl.client.NamespacedResourceClient;
 import com.michelin.kafkactl.model.ApiResource;
 import com.michelin.kafkactl.model.Resource;
 import com.michelin.kafkactl.model.SubjectCompatibility;
+import com.michelin.kafkactl.model.request.ConnectorOffsets;
 import com.michelin.kafkactl.model.request.DeleteResourceRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -1681,6 +1682,61 @@ class ResourceServiceTest {
 
         Optional<Resource> actual =
                 resourceService.resetConnectorOffsets("namespace", "connector", cmd.getCommandSpec());
+
+        assertTrue(actual.isEmpty());
+        verify(formatService).displayError(exception, CONNECTOR, "connector", cmd.getCommandSpec());
+    }
+
+    @Test
+    void shouldAlterConnectorOffsets() {
+        Resource response = Resource.builder()
+                .kind("ConnectorResetOffsetsResponse")
+                .metadata(Resource.Metadata.builder().name("connector").build())
+                .status(Map.of("code", "RESET"))
+                .build();
+        ConnectorOffsets offsets = new ConnectorOffsets(
+                List.of(new ConnectorOffsets.ConnectorOffset(Map.of("partition", 0), Map.of("offset", 10))));
+        CommandLine cmd = new CommandLine(new Kafkactl());
+
+        when(namespacedClient.alterConnectorOffsets(any(), any(), any(), any())).thenReturn(HttpResponse.ok(response));
+
+        Optional<Resource> actual =
+                resourceService.alterConnectorOffsets("namespace", "connector", offsets, cmd.getCommandSpec());
+
+        assertEquals(Optional.of(response), actual);
+        verify(namespacedClient).alterConnectorOffsets("namespace", "connector", offsets, null);
+    }
+
+    @Test
+    void shouldAlterConnectorOffsetsNotFound() {
+        ConnectorOffsets offsets = new ConnectorOffsets(List.of());
+        CommandLine cmd = new CommandLine(new Kafkactl());
+
+        when(namespacedClient.alterConnectorOffsets(any(), any(), any(), any())).thenReturn(HttpResponse.notFound());
+
+        Optional<Resource> actual =
+                resourceService.alterConnectorOffsets("namespace", "connector", offsets, cmd.getCommandSpec());
+
+        assertTrue(actual.isEmpty());
+        verify(formatService)
+                .displayError(
+                        argThat(exception -> exception.getStatus().equals(HttpStatus.NOT_FOUND)
+                                && exception.getMessage().equals("Not Found")),
+                        eq(CONNECTOR),
+                        eq("connector"),
+                        eq(cmd.getCommandSpec()));
+    }
+
+    @Test
+    void shouldAlterConnectorOffsetsFail() {
+        ConnectorOffsets offsets = new ConnectorOffsets(List.of());
+        CommandLine cmd = new CommandLine(new Kafkactl());
+        HttpClientResponseException exception = new HttpClientResponseException("error", HttpResponse.serverError());
+
+        when(namespacedClient.alterConnectorOffsets(any(), any(), any(), any())).thenThrow(exception);
+
+        Optional<Resource> actual =
+                resourceService.alterConnectorOffsets("namespace", "connector", offsets, cmd.getCommandSpec());
 
         assertTrue(actual.isEmpty());
         verify(formatService).displayError(exception, CONNECTOR, "connector", cmd.getCommandSpec());


### PR DESCRIPTION
## Context

The first feature of the connector offset epic introduced support for fully resetting connector offsets in [michelin/kafkactl#380](https://github.com/michelin/kafkactl/pull/380).

This change extends that flow so users can alter or partially reset source connector offsets directly from `kafkactl`. It allows users to target specific source partitions and either assign a connector-specific offset or reset the selected partition by setting its offset to `null`.

The corresponding Ns4Kafka API support is implemented in [michelin/ns4kafka#826](https://github.com/michelin/ns4kafka/pull/826).

## Proposed solution

I introduced a dedicated CLI flow for connector offset alteration through:

```console
kafkactl connector alter-offsets <connector-name> -f <offsets-file>
```

The command accepts a YAML payload using the Kafka Connect alter-offsets format. This keeps the operation aligned with the existing connector command structure while supporting both targeted offset alteration and partial reset.

Example payload:

```yaml
offsets:
  - partition:
      task.id: 0
    offset:
      current.iteration: 100
  - partition:
      task.id: 1
    offset: null
```

## Implementation

I added a connector offsets request model representing the Kafka Connect `offsets` payload.

I then added client-side support for the Ns4Kafka endpoint:

```text
PATCH /api/namespaces/{namespace}/connectors/{connector}/offsets
```

The new endpoint is wired through the resource service, including standard response, not-found, and HTTP error handling.

On the CLI side, I added and registered the `connector alter-offsets` subcommand. The command:

- accepts one connector name and a required YAML file
- parses the connector-specific partition and offset payload
- sends the payload to Ns4Kafka
- displays the existing `ConnectorResetOffsetsResponse` result

I also updated the README with command usage and examples for altering or partially resetting connector offsets.

## Tests

I added command-level tests covering:

- YAML payload parsing and forwarding
- successful offset alteration and response display
- empty response handling
- access to the `alter-offsets` subcommand help without parent parameters

I added service-level tests covering:

- successful API delegation
- not-found response handling
- generic HTTP failure handling

The full test suite and Spotless checks pass.

## Remark

This change complements the full connector offset reset introduced in [michelin/kafkactl#380](https://github.com/michelin/kafkactl/pull/380). Together, the two commands support both complete reset and targeted alteration or partial reset of connector offsets.

The server-side implementation used by this command is available in [michelin/ns4kafka#826](https://github.com/michelin/ns4kafka/pull/826).
